### PR TITLE
feat: Add CRUD for PrinterService module RP-60

### DIFF
--- a/PrinterService/pom.xml
+++ b/PrinterService/pom.xml
@@ -54,6 +54,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/PrinterService/src/main/java/repro3d/EntryPointPrinterService.java
+++ b/PrinterService/src/main/java/repro3d/EntryPointPrinterService.java
@@ -1,0 +1,23 @@
+package repro3d;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+/**
+ * Main application class for PrinterService.
+ * Uses DiscoveryClient.
+ */
+@SpringBootApplication
+@EnableDiscoveryClient
+public class EntryPointPrinterService {
+
+    /**
+     * Main method to start the PrinterService application.
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(EntryPointPrinterService.class, args);
+    }
+
+}

--- a/PrinterService/src/main/java/repro3d/controller/JobController.java
+++ b/PrinterService/src/main/java/repro3d/controller/JobController.java
@@ -14,7 +14,7 @@ import repro3d.utils.ApiResponse;
  * updating, and deleting jobs.
  */
 @RestController
-@RequestMapping("/jobs")
+@RequestMapping("/job")
 public class JobController {
 
     private final JobService jobService;

--- a/PrinterService/src/main/java/repro3d/controller/JobController.java
+++ b/PrinterService/src/main/java/repro3d/controller/JobController.java
@@ -1,0 +1,91 @@
+package repro3d.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import repro3d.model.Job;
+import repro3d.service.JobService;
+import repro3d.utils.ApiResponse;
+
+/**
+ * Controller for managing {@code Job} entities.
+ * <p>
+ * Provides RESTful APIs for CRUD operations on jobs, including creating, retrieving,
+ * updating, and deleting jobs.
+ */
+@RestController
+@RequestMapping("/jobs")
+public class JobController {
+
+    private final JobService jobService;
+
+    /**
+     * Constructs a {@code JobController} with the necessary {@link JobService}.
+     *
+     * @param jobService The service used to perform operations on jobs.
+     */
+    @Autowired
+    public JobController(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    /**
+     * Creates a new job.
+     *
+     * @param job The job to create.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating
+     *         the result of the create operation.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse> createJob(@RequestBody Job job) {
+        return jobService.createJob(job);
+    }
+
+    /**
+     * Retrieves a job by its ID.
+     *
+     * @param id The ID of the job to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the job
+     *         if found, or an error message otherwise.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse> getJobById(@PathVariable Long id) {
+        return jobService.getJobById(id);
+    }
+
+    /**
+     * Retrieves all jobs.
+     *
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the list
+     *         of all jobs. If no jobs are found, returns an empty list.
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse> getAllJobs() {
+        return jobService.getAllJobs();
+    }
+
+    /**
+     * Updates the details of an existing job.
+     *
+     * @param id  The ID of the job to update.
+     * @param job The new details for the job.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating
+     *         the result of the update operation.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse> updateJob(@PathVariable Long id, @RequestBody Job job) {
+        return jobService.updateJob(id, job);
+    }
+
+    /**
+     * Deletes a job by its ID.
+     *
+     * @param id The ID of the job to delete.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating
+     *         the result of the delete operation.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse> deleteJob(@PathVariable Long id) {
+        return jobService.deleteJob(id);
+    }
+}

--- a/PrinterService/src/main/java/repro3d/controller/PrinterController.java
+++ b/PrinterService/src/main/java/repro3d/controller/PrinterController.java
@@ -1,0 +1,95 @@
+package repro3d.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import repro3d.model.Printer;
+import repro3d.service.PrinterService;
+import repro3d.utils.ApiResponse;
+
+import java.util.List;
+
+/**
+ * Controller for managing {@code Printer} entities.
+ * <p>
+ * This class provides RESTful web APIs to perform CRUD operations on printers,
+ * including creating new printers, retrieving details of a specific printer,
+ * updating printer information, and deleting printers.
+ */
+@RestController
+@RequestMapping("/printers")
+public class PrinterController {
+
+    private final PrinterService printerService;
+
+    /**
+     * Constructs a {@code PrinterController} with a dependency on {@link PrinterService}.
+     * This service is injected at runtime by Spring Framework's dependency injection facilities.
+     *
+     * @param printerService The service used for operations on {@link Printer} entities.
+     */
+    @Autowired
+    public PrinterController(PrinterService printerService) {
+        this.printerService = printerService;
+    }
+
+    /**
+     * Creates a new printer and saves it to the database.
+     *
+     * @param printer The {@link Printer} entity to be created.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} that includes
+     *         the result of the create operation, along with the created printer entity.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse> createPrinter(@RequestBody Printer printer) {
+        return printerService.createPrinter(printer);
+    }
+
+    /**
+     * Retrieves all printers.
+     *
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list
+     *         of all printers.
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse> getAllPrinters() {
+        return printerService.getAllPrinters();
+    }
+
+    /**
+     * Retrieves the details of a printer identified by its ID.
+     *
+     * @param id The ID of the printer to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} that includes
+     *         the details of the requested printer, or an error message if not found.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse> getPrinterById(@PathVariable Long id) {
+        return printerService.getPrinterById(id);
+    }
+
+    /**
+     * Updates the information of an existing printer identified by its ID.
+     *
+     * @param id The ID of the printer to update.
+     * @param printer The new information for the printer.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} that indicates
+     *         the result of the update operation.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse> updatePrinter(@PathVariable Long id, @RequestBody Printer printer) {
+        return printerService.updatePrinter(id, printer);
+    }
+
+    /**
+     * Deletes a printer identified by its ID from the database.
+     *
+     * @param id The ID of the printer to delete.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} that indicates
+     *         the result of the delete operation.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse> deletePrinter(@PathVariable Long id) {
+        return printerService.deletePrinter(id);
+    }
+}

--- a/PrinterService/src/main/java/repro3d/controller/PrinterController.java
+++ b/PrinterService/src/main/java/repro3d/controller/PrinterController.java
@@ -17,7 +17,7 @@ import java.util.List;
  * updating printer information, and deleting printers.
  */
 @RestController
-@RequestMapping("/printers")
+@RequestMapping("/printer")
 public class PrinterController {
 
     private final PrinterService printerService;

--- a/PrinterService/src/main/java/repro3d/controller/StatusController.java
+++ b/PrinterService/src/main/java/repro3d/controller/StatusController.java
@@ -15,7 +15,7 @@ import repro3d.utils.ApiResponse;
  * the ability to retrieve a list of all statuses.
  */
 @RestController
-@RequestMapping("/statuses")
+@RequestMapping("/status")
 public class StatusController {
 
     private final StatusService statusService;

--- a/PrinterService/src/main/java/repro3d/controller/StatusController.java
+++ b/PrinterService/src/main/java/repro3d/controller/StatusController.java
@@ -1,0 +1,81 @@
+package repro3d.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import repro3d.model.Status;
+import repro3d.service.StatusService;
+import repro3d.utils.ApiResponse;
+
+/**
+ * Controller for managing {@code Status} entities.
+ * <p>
+ * This controller provides RESTful APIs to perform CRUD operations on status entities,
+ * allowing for the creation, retrieval, update, and deletion of statuses, as well as
+ * the ability to retrieve a list of all statuses.
+ */
+@RestController
+@RequestMapping("/statuses")
+public class StatusController {
+
+    private final StatusService statusService;
+
+    /**
+     * Constructs a {@code StatusController} with the necessary {@link StatusService}.
+     *
+     * @param statusService The service used to perform operations on status entities.
+     */
+    @Autowired
+    public StatusController(StatusService statusService) {
+        this.statusService = statusService;
+    }
+
+    /**
+     * Creates a new status.
+     *
+     * @param status The status to create.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating
+     *         the result of the create operation.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse> createStatus(@RequestBody Status status) {
+        return statusService.createStatus(status);
+    }
+
+    /**
+     * Retrieves a specific status by its ID.
+     *
+     * @param id The ID of the status to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the status
+     *         if found, or an error message otherwise.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse> getStatusById(@PathVariable Long id) {
+        return statusService.getStatusById(id);
+    }
+
+    /**
+     * Updates an existing status.
+     *
+     * @param id     The ID of the status to update.
+     * @param status The new details for the status.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating
+     *         the result of the update operation.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse> updateStatus(@PathVariable Long id, @RequestBody Status status) {
+        return statusService.updateStatus(id, status);
+    }
+
+    /**
+     * Deletes a status by its ID.
+     *
+     * @param id The ID of the status to delete.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating
+     *         the result of the delete operation.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse> deleteStatus(@PathVariable Long id) {
+        return statusService.deleteStatus(id);
+    }
+}

--- a/PrinterService/src/main/java/repro3d/model/Item.java
+++ b/PrinterService/src/main/java/repro3d/model/Item.java
@@ -1,0 +1,67 @@
+package repro3d.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents an item entity within the OrderDB schema.
+ * It is duplicated in otder to be used within PrinterService module.
+ */
+@Entity
+@Table(name = "item", schema = "OrderDB")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Item {
+
+    /**
+     * The unique identifier for the item.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long item_id;
+
+    /**
+     * The name of the item.
+     */
+    @Column(length = 45)
+    private String name;
+
+    /**
+     * A brief description of the item.
+     */
+    @Column(length = 45)
+    private String description;
+
+    /**
+     * The estimated time (in minutes) it takes to produce the item.
+     */
+    @Column
+    private Integer est_time;
+
+    /**
+     * The dimensions of the item, including length, width, and height.
+     */
+    @Column(length = 45)
+    private String dimensions;
+
+    /**
+     * A reference to a g-code file associated with the item.
+     */
+    @Column(length = 256)
+    private String file_ref;
+
+    /**
+     * The material from which the item is intended to be made.
+     */
+    @Column(length = 45)
+    private String material;
+
+    /**
+     * The cost associated with the item.
+     */
+    @Column(length = 45)
+    private String cost;
+}

--- a/PrinterService/src/main/java/repro3d/model/Job.java
+++ b/PrinterService/src/main/java/repro3d/model/Job.java
@@ -15,7 +15,7 @@ import java.util.Date;
  * by their item ID, which references an external entity in the OrderDB.
  */
 @Entity
-@Table(name = "job")
+@Table(name = "job",schema = "PrinterDB")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -29,10 +29,11 @@ public class Job {
     private Long job_id;
 
     /**
-     * The item ID this job is associated with. It references an external entity in OrderDB.
+     * The item ID this job is associated with.
      */
-    @Column
-    private Long item_id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", referencedColumnName = "item_id")
+    private Item item;
 
     /**
      * The printer assigned to this job. It is a many-to-one relationship since

--- a/PrinterService/src/main/java/repro3d/model/Job.java
+++ b/PrinterService/src/main/java/repro3d/model/Job.java
@@ -1,0 +1,64 @@
+package repro3d.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * Represents a print job entity in the system.
+ * <p>
+ * This entity stores information about a job, including its associated printer,
+ * status, and the start and end dates of the job. It is linked to specific items
+ * by their item ID, which references an external entity in the OrderDB.
+ */
+@Entity
+@Table(name = "job")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Job {
+
+    /**
+     * The unique identifier for the job.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long job_id;
+
+    /**
+     * The item ID this job is associated with. It references an external entity in OrderDB.
+     */
+    @Column
+    private Long item_id;
+
+    /**
+     * The printer assigned to this job. It is a many-to-one relationship since
+     * multiple jobs can be assigned to a single printer.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "printer_id")
+    private Printer printer;
+
+    /**
+     * The current status of the job. It is a many-to-one relationship since
+     * multiple jobs can share the same status (e.g., 'Pending', 'Completed').
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_id")
+    private Status status;
+
+    /**
+     * The start date and time of the job.
+     */
+    @Column
+    private Date start_date;
+
+    /**
+     * The end date and time of the job.
+     */
+    @Column
+    private Date end_date;
+}

--- a/PrinterService/src/main/java/repro3d/model/Printer.java
+++ b/PrinterService/src/main/java/repro3d/model/Printer.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
  * location, IP address, and an API key for authentication or integration purposes.
  */
 @Entity
-@Table(name = "printer")
+@Table(name = "printer",schema = "PrinterDB")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/PrinterService/src/main/java/repro3d/model/Printer.java
+++ b/PrinterService/src/main/java/repro3d/model/Printer.java
@@ -1,0 +1,51 @@
+package repro3d.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a printer entity within the system.
+ * <p>
+ * This entity stores detailed information about a printer, including its name,
+ * location, IP address, and an API key for authentication or integration purposes.
+ */
+@Entity
+@Table(name = "printer")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Printer {
+
+    /**
+     * The unique identifier for the printer.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long printer_id;
+
+    /**
+     * The name of the printer. This can be a model name or a custom name given to the printer.
+     */
+    @Column(length = 45)
+    private String name;
+
+    /**
+     * The location of the printer.
+     */
+    @Column(length = 45)
+    private String location;
+
+    /**
+     * The IP address of the printer. Used for network communications and identification.
+     */
+    @Column(length = 50)
+    private String ip_addr;
+
+    /**
+     * An OctoPrint API key associated with the printer.
+     */
+    @Column(length = 32)
+    private String apikey;
+}

--- a/PrinterService/src/main/java/repro3d/model/Status.java
+++ b/PrinterService/src/main/java/repro3d/model/Status.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
  * of a job.
  */
 @Entity
-@Table(name = "status")
+@Table(name = "status",schema = "PrinterDB")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/PrinterService/src/main/java/repro3d/model/Status.java
+++ b/PrinterService/src/main/java/repro3d/model/Status.java
@@ -1,0 +1,35 @@
+package repro3d.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a status entity for jobs in the system.
+ * <p>
+ * This entity is used to define the various states a job can be in, such as 'Pending',
+ * 'In Progress', 'Completed', etc. It provides a way to track and manage the lifecycle
+ * of a job.
+ */
+@Entity
+@Table(name = "status")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Status {
+
+    /**
+     * The unique identifier for the status.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long status_id;
+
+    /**
+     * The name of the status. This describes the current state of a job and can include
+     * values like 'Pending', 'In Progress', 'Completed', and more.
+     */
+    @Column(length = 45)
+    private String status;
+}

--- a/PrinterService/src/main/java/repro3d/repository/ItemRepository.java
+++ b/PrinterService/src/main/java/repro3d/repository/ItemRepository.java
@@ -1,0 +1,16 @@
+package repro3d.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import repro3d.model.Item;
+import repro3d.model.Job;
+
+/**
+ * Repository interface for {@link Item} entities.
+ * <p>
+ * This interface extends {@link JpaRepository}, and is used solely to check for existence of an item
+ * in applicable methods.
+ */
+@Repository
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/PrinterService/src/main/java/repro3d/repository/JobRepository.java
+++ b/PrinterService/src/main/java/repro3d/repository/JobRepository.java
@@ -1,0 +1,15 @@
+package repro3d.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import repro3d.model.Job;
+
+/**
+ * Repository interface for {@link Job} entities.
+ * <p>
+ * This interface extends {@link JpaRepository}, providing CRUD operations and additional
+ * methods to interact with the database for {@link Job} entities.
+ */
+@Repository
+public interface JobRepository extends JpaRepository<Job, Long> {
+}

--- a/PrinterService/src/main/java/repro3d/repository/PrinterRepository.java
+++ b/PrinterService/src/main/java/repro3d/repository/PrinterRepository.java
@@ -1,0 +1,15 @@
+package repro3d.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import repro3d.model.Printer;
+
+/**
+ * Repository interface for {@link Printer} entities.
+ * <p>
+ * Acts as a mechanism for encapsulating storage, retrieval, and search behavior which emulates a collection of objects.
+ * Through extending {@link JpaRepository}, it inherits standard CRUD operations and the ability to define more complex queries.
+ */
+@Repository
+public interface PrinterRepository extends JpaRepository<Printer, Long> {
+}

--- a/PrinterService/src/main/java/repro3d/repository/StatusRepository.java
+++ b/PrinterService/src/main/java/repro3d/repository/StatusRepository.java
@@ -1,0 +1,16 @@
+package repro3d.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import repro3d.model.Status;
+
+/**
+ * Repository interface for {@link Status} entities.
+ * <p>
+ * Provides an abstraction layer to manage the set of status entities. By extending
+ * {@link JpaRepository}, it automatically inherits a suite of CRUD operations and
+ * the capability to define custom queries for interacting with the database.
+ */
+@Repository
+public interface StatusRepository extends JpaRepository<Status, Long> {
+}

--- a/PrinterService/src/main/java/repro3d/service/JobService.java
+++ b/PrinterService/src/main/java/repro3d/service/JobService.java
@@ -1,0 +1,104 @@
+package repro3d.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import repro3d.model.Job;
+import repro3d.repository.JobRepository;
+import repro3d.utils.ApiResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service class for handling operations related to {@link Job} entities.
+ * <p>
+ * Encapsulates the business logic for creating, retrieving, updating, and deleting jobs,
+ * interacting with the {@link JobRepository} to perform these operations.
+ */
+@Service
+public class JobService {
+
+    private final JobRepository jobRepository;
+
+    /**
+     * Constructs a {@code JobService} with the necessary {@link JobRepository}.
+     *
+     * @param jobRepository The repository used for data operations on jobs.
+     */
+    @Autowired
+    public JobService(JobRepository jobRepository) {
+        this.jobRepository = jobRepository;
+    }
+
+    /**
+     * Creates and saves a new job in the repository.
+     *
+     * @param job The job to be created and saved.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the result of the create operation.
+     */
+    public ResponseEntity<ApiResponse> createJob(Job job) {
+        Job savedJob = jobRepository.save(job);
+        return ResponseEntity.ok(new ApiResponse(true, "Job created successfully.", savedJob));
+    }
+
+    /**
+     * Retrieves a job by its ID.
+     *
+     * @param id The ID of the job to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the job if found, or an error message otherwise.
+     */
+    public ResponseEntity<ApiResponse> getJobById(Long id) {
+        Optional<Job> job = jobRepository.findById(id);
+        if (job.isPresent()) {
+            return ResponseEntity.ok(new ApiResponse(true, "Job found.", job.get()));
+        } else {
+            return ResponseEntity.ok(new ApiResponse(false, "Job not found for ID: " + id, null));
+        }
+    }
+
+    /**
+     * Retrieves all jobs.
+     *
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list of all jobs.
+     */
+    public ResponseEntity<ApiResponse> getAllJobs() {
+        List<Job> jobs = jobRepository.findAll();
+        return ResponseEntity.ok(new ApiResponse(true, "Jobs retrieved successfully", jobs));
+    }
+
+    /**
+     * Updates an existing job identified by its ID with new details.
+     *
+     * @param id The ID of the job to update.
+     * @param jobDetails The new details for the job.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the updated job, or an error message if the job was not found.
+     */
+    public ResponseEntity<ApiResponse> updateJob(Long id, Job jobDetails) {
+        return jobRepository.findById(id)
+                .map(job -> {
+                    job.setItem_id(jobDetails.getItem_id());
+                    job.setPrinter(jobDetails.getPrinter());
+                    job.setStatus(jobDetails.getStatus());
+                    job.setStart_date(jobDetails.getStart_date());
+                    job.setEnd_date(jobDetails.getEnd_date());
+                    Job updatedJob = jobRepository.save(job);
+                    return ResponseEntity.ok(new ApiResponse(true, "Job updated successfully.", updatedJob));
+                }).orElseGet(() -> ResponseEntity.ok(new ApiResponse(false, "Job not found for ID: " + id, null)));
+    }
+
+    /**
+     * Deletes a job from the repository identified by its ID.
+     *
+     * @param id The ID of the job to delete.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating the result of the delete operation.
+     */
+    public ResponseEntity<ApiResponse> deleteJob(Long id) {
+        if (jobRepository.existsById(id)) {
+            jobRepository.deleteById(id);
+            return ResponseEntity.ok(new ApiResponse(true, "Job deleted successfully.", null));
+        } else {
+            return ResponseEntity.ok(new ApiResponse(false, "Job not found for ID: " + id, null));
+        }
+    }
+}

--- a/PrinterService/src/main/java/repro3d/service/PrinterService.java
+++ b/PrinterService/src/main/java/repro3d/service/PrinterService.java
@@ -1,0 +1,99 @@
+package repro3d.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import repro3d.model.Printer;
+import repro3d.repository.PrinterRepository;
+import repro3d.utils.ApiResponse;
+
+import java.util.List;
+
+/**
+ * Service class for handling operations related to {@link Printer} entities.
+ * <p>
+ * Encapsulates the business logic for creating, retrieving, updating, and deleting printers,
+ * interacting with the {@link PrinterRepository} to perform these operations.
+ */
+@Service
+public class PrinterService {
+
+    private final PrinterRepository printerRepository;
+
+    /**
+     * Constructs a {@code PrinterService} with the necessary {@link PrinterRepository}.
+     *
+     * @param printerRepository The repository used for data operations on printers.
+     */
+    @Autowired
+    public PrinterService(PrinterRepository printerRepository) {
+        this.printerRepository = printerRepository;
+    }
+
+    /**
+     * Creates and saves a new printer in the repository.
+     *
+     * @param printer The printer to be created and saved.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the result of the create operation.
+     */
+    public ResponseEntity<ApiResponse> createPrinter(Printer printer) {
+        Printer savedPrinter = printerRepository.save(printer);
+        return ResponseEntity.ok(new ApiResponse(true, "Printer created successfully.", savedPrinter));
+    }
+
+    /**
+     * Retrieves all printers.
+     *
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list
+     *         of all printers.
+     */
+    public ResponseEntity<ApiResponse> getAllPrinters() {
+        List<Printer> printers = printerRepository.findAll();
+        return ResponseEntity.ok(new ApiResponse(true, "Printers retrieved successfully", printers));
+    }
+
+    /**
+     * Retrieves a printer by its ID.
+     *
+     * @param id The ID of the printer to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the printer if found, or an error message otherwise.
+     */
+    public ResponseEntity<ApiResponse> getPrinterById(Long id) {
+        return printerRepository.findById(id)
+                .map(printer -> ResponseEntity.ok(new ApiResponse(true, "Printer found.", printer)))
+                .orElseGet(() -> ResponseEntity.ok(new ApiResponse(false, "Printer not found for ID: " + id, null)));
+    }
+
+    /**
+     * Updates an existing printer identified by its ID with new details.
+     *
+     * @param id The ID of the printer to update.
+     * @param printerDetails The new details for the printer.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the updated printer, or an error message if the printer was not found.
+     */
+    public ResponseEntity<ApiResponse> updatePrinter(Long id, Printer printerDetails) {
+        return printerRepository.findById(id)
+                .map(printer -> {
+                    printer.setName(printerDetails.getName());
+                    printer.setLocation(printerDetails.getLocation());
+                    printer.setIp_addr(printerDetails.getIp_addr());
+                    printer.setApikey(printerDetails.getApikey());
+                    Printer updatedPrinter = printerRepository.save(printer);
+                    return ResponseEntity.ok(new ApiResponse(true, "Printer updated successfully.", updatedPrinter));
+                }).orElseGet(() -> ResponseEntity.ok(new ApiResponse(false, "Printer not found for ID: " + id, null)));
+    }
+
+    /**
+     * Deletes a printer from the repository identified by its ID.
+     *
+     * @param id The ID of the printer to delete.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating the result of the delete operation.
+     */
+    public ResponseEntity<ApiResponse> deletePrinter(Long id) {
+        return printerRepository.findById(id)
+                .map(printer -> {
+                    printerRepository.deleteById(id);
+                    return ResponseEntity.ok(new ApiResponse(true, "Printer deleted successfully.", null));
+                }).orElseGet(() -> ResponseEntity.ok(new ApiResponse(false, "Printer not found for ID: " + id, null)));
+    }
+}

--- a/PrinterService/src/main/java/repro3d/service/StatusService.java
+++ b/PrinterService/src/main/java/repro3d/service/StatusService.java
@@ -1,0 +1,101 @@
+package repro3d.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import repro3d.model.Status;
+import repro3d.repository.StatusRepository;
+import repro3d.utils.ApiResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service class for handling operations related to {@link Status} entities.
+ * <p>
+ * This class encapsulates the business logic for creating, retrieving, updating, and deleting status entities,
+ * interfacing with the {@link StatusRepository} to perform these operations. It provides a centralized access point
+ * for status management within the application.
+ */
+@Service
+public class StatusService {
+
+    private final StatusRepository statusRepository;
+
+    /**
+     * Constructs a {@code StatusService} with a dependency on the {@link StatusRepository}.
+     *
+     * @param statusRepository The repository used for data operations on statuses.
+     */
+    @Autowired
+    public StatusService(StatusRepository statusRepository) {
+        this.statusRepository = statusRepository;
+    }
+
+    /**
+     * Creates a new status in the repository.
+     *
+     * @param status The status object to be created.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the result of the create operation.
+     */
+    public ResponseEntity<ApiResponse> createStatus(Status status) {
+        Status savedStatus = statusRepository.save(status);
+        return ResponseEntity.ok(new ApiResponse(true, "Status created successfully.", savedStatus));
+    }
+
+    /**
+     * Retrieves a specific status by its ID.
+     *
+     * @param id The ID of the status to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the status if found, or an error message otherwise.
+     */
+    public ResponseEntity<ApiResponse> getStatusById(Long id) {
+        Optional<Status> status = statusRepository.findById(id);
+        if (status.isPresent()) {
+            return ResponseEntity.ok(new ApiResponse(true, "Status found.", status.get()));
+        } else {
+            return ResponseEntity.ok(new ApiResponse(false, "Status not found for ID: " + id, null));
+        }
+    }
+
+    /**
+     * Retrieves all statuses from the repository.
+     *
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list of all statuses.
+     */
+    public ResponseEntity<ApiResponse> getAllStatuses() {
+        List<Status> statuses = statusRepository.findAll();
+        return ResponseEntity.ok(new ApiResponse(true, "Statuses retrieved successfully", statuses));
+    }
+
+    /**
+     * Updates an existing status identified by its ID with new details.
+     *
+     * @param id The ID of the status to update.
+     * @param statusDetails The details to update the status with.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the updated status, or an error message if the status was not found.
+     */
+    public ResponseEntity<ApiResponse> updateStatus(Long id, Status statusDetails) {
+        return statusRepository.findById(id)
+                .map(status -> {
+                    status.setStatus(statusDetails.getStatus());
+                    Status updatedStatus = statusRepository.save(status);
+                    return ResponseEntity.ok(new ApiResponse(true, "Status updated successfully.", updatedStatus));
+                }).orElseGet(() -> ResponseEntity.ok(new ApiResponse(false, "Status not found for ID: " + id, null)));
+    }
+
+    /**
+     * Deletes a status from the repository based on its ID.
+     *
+     * @param id The ID of the status to delete.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating the result of the delete operation.
+     */
+    public ResponseEntity<ApiResponse> deleteStatus(Long id) {
+        if (statusRepository.existsById(id)) {
+            statusRepository.deleteById(id);
+            return ResponseEntity.ok(new ApiResponse(true, "Status deleted successfully.", null));
+        } else {
+            return ResponseEntity.ok(new ApiResponse(false, "Status not found for ID: " + id, null));
+        }
+    }
+}

--- a/PrinterService/src/main/java/repro3d/utils/ApiResponse.java
+++ b/PrinterService/src/main/java/repro3d/utils/ApiResponse.java
@@ -1,0 +1,92 @@
+package repro3d.utils;
+
+/**
+ * Represents a standardized response structure for API calls.
+ * This class encapsulates the details of the response, including success status, a message, and any associated data.
+ */
+public class ApiResponse {
+
+    /**
+     * Indicates the success or failure of the API call.
+     */
+    private boolean success;
+
+    /**
+     * A message providing additional details about the API call,
+     * typically used for providing information on errors or confirmation messages.
+     */
+    private String message;
+
+    /**
+     * The data payload returned by the API call.
+     * This can be any type of object, including null, depending on the context of the API response.
+     */
+    private Object data;
+
+    /**
+     * Constructs a new ApiResponse with specified success status, message, and data.
+     *
+     * @param success A boolean indicating the success status of the API call.
+     * @param message A String containing additional information about the API response.
+     * @param data The data object containing the payload of the API response.
+     */
+    public ApiResponse(boolean success, String message, Object data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    /**
+     * Returns the success status of the API response.
+     *
+     * @return A boolean representing the success status.
+     */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /**
+     * Sets the success status of the API response.
+     *
+     * @param success A boolean representing the new success status.
+     */
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    /**
+     * Returns the message associated with the API response.
+     *
+     * @return A String containing the response message.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Sets the message for the API response.
+     *
+     * @param message A String containing the new message.
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Returns the data object of the API response.
+     *
+     * @return An Object representing the data of the API response.
+     */
+    public Object getData() {
+        return data;
+    }
+
+    /**
+     * Sets the data object for the API response.
+     *
+     * @param data An Object representing the new data for the API response.
+     */
+    public void setData(Object data) {
+        this.data = data;
+    }
+}

--- a/PrinterService/src/test/java/org/repro3d/service/JobServiceTest.java
+++ b/PrinterService/src/test/java/org/repro3d/service/JobServiceTest.java
@@ -3,6 +3,7 @@ package repro3d.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import repro3d.model.Item;
 import repro3d.model.Job;
+import repro3d.repository.ItemRepository;
 import repro3d.repository.JobRepository;
 import repro3d.utils.ApiResponse;
 
@@ -31,16 +34,39 @@ public class JobServiceTest {
     @MockBean
     private JobRepository jobRepository;
 
+    @MockBean
+    private ItemRepository itemRepository;
+
     @Test
     public void testCreateJob() {
         Job job = new Job();
+        Item item = new Item();
+        item.setItem_id(1L); // Set the item ID as needed for the test
+        job.setItem(item);
         job.setJob_id(1L);
+
+        when(itemRepository.existsById(any(Long.class))).thenReturn(true); // Assuming the item exists.
         when(jobRepository.save(any(Job.class))).thenReturn(job);
 
         ResponseEntity<ApiResponse> response = jobService.createJob(job);
         assertEquals("Job created successfully.", response.getBody().getMessage());
         assertEquals(true, response.getBody().isSuccess());
         assertEquals(job, response.getBody().getData());
+    }
+
+    @Test
+    public void testCreateJobItemNotFound() {
+        Job job = new Job();
+        Item item = new Item();
+        item.setItem_id(1L);
+        job.setItem(item);
+
+        when(itemRepository.existsById(any(Long.class))).thenReturn(false); // Item does not exist.
+
+        ResponseEntity<ApiResponse> response = jobService.createJob(job);
+        assertEquals("Item not found for ID: " + item.getItem_id(), response.getBody().getMessage());
+        assertEquals(false, response.getBody().isSuccess());
+        verify(jobRepository, never()).save(any(Job.class)); // Ensure job is not saved.
     }
 
     @Test
@@ -72,19 +98,46 @@ public class JobServiceTest {
     @Test
     public void testUpdateJob() {
         Job existingJob = new Job();
+        Item item = new Item();
+        item.setItem_id(1L);
+        existingJob.setItem(item);
         existingJob.setJob_id(1L);
-        existingJob.setItem_id(1L);
 
         Job updatedDetails = new Job();
-        updatedDetails.setItem_id(2L);
+        Item updatedItem = new Item();
+        updatedItem.setItem_id(2L);
+        updatedDetails.setItem(updatedItem);
 
         when(jobRepository.findById(1L)).thenReturn(Optional.of(existingJob));
+        when(itemRepository.existsById(2L)).thenReturn(true);
         when(jobRepository.save(any(Job.class))).thenReturn(existingJob);
 
         ResponseEntity<ApiResponse> response = jobService.updateJob(1L, updatedDetails);
         assertEquals("Job updated successfully.", response.getBody().getMessage());
         assertEquals(true, response.getBody().isSuccess());
         verify(jobRepository).save(existingJob);
+    }
+
+    @Test
+    public void testUpdateJobItemNotFound() {
+        Job existingJob = new Job();
+        Item item = new Item();
+        item.setItem_id(1L);
+        existingJob.setItem(item);
+        existingJob.setJob_id(1L);
+
+        Job updatedDetails = new Job();
+        Item updatedItem = new Item();
+        updatedItem.setItem_id(2L);
+        updatedDetails.setItem(updatedItem);
+
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(existingJob));
+        when(itemRepository.existsById(2L)).thenReturn(false);
+
+        ResponseEntity<ApiResponse> response = jobService.updateJob(1L, updatedDetails);
+        assertEquals("Item not found for ID: " + updatedItem.getItem_id(), response.getBody().getMessage());
+        assertEquals(false, response.getBody().isSuccess());
+        verify(jobRepository, never()).save(any(Job.class));
     }
 
     @Test

--- a/PrinterService/src/test/java/org/repro3d/service/JobServiceTest.java
+++ b/PrinterService/src/test/java/org/repro3d/service/JobServiceTest.java
@@ -1,0 +1,99 @@
+package repro3d.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import repro3d.model.Job;
+import repro3d.repository.JobRepository;
+import repro3d.utils.ApiResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class JobServiceTest {
+
+    @Autowired
+    private JobService jobService;
+
+    @MockBean
+    private JobRepository jobRepository;
+
+    @Test
+    public void testCreateJob() {
+        Job job = new Job();
+        job.setJob_id(1L);
+        when(jobRepository.save(any(Job.class))).thenReturn(job);
+
+        ResponseEntity<ApiResponse> response = jobService.createJob(job);
+        assertEquals("Job created successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(job, response.getBody().getData());
+    }
+
+    @Test
+    public void testGetJobById() {
+        Job job = new Job();
+        job.setJob_id(1L);
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(job));
+
+        ResponseEntity<ApiResponse> response = jobService.getJobById(1L);
+        assertEquals("Job found.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(job, response.getBody().getData());
+    }
+
+    @Test
+    public void testGetAllJobs() {
+        Job job1 = new Job();
+        job1.setJob_id(1L);
+        Job job2 = new Job();
+        job2.setJob_id(2L);
+        when(jobRepository.findAll()).thenReturn(Arrays.asList(job1, job2));
+
+        ResponseEntity<ApiResponse> response = jobService.getAllJobs();
+        assertEquals("Jobs retrieved successfully", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(Arrays.asList(job1, job2), response.getBody().getData());
+    }
+
+    @Test
+    public void testUpdateJob() {
+        Job existingJob = new Job();
+        existingJob.setJob_id(1L);
+        existingJob.setItem_id(1L);
+
+        Job updatedDetails = new Job();
+        updatedDetails.setItem_id(2L);
+
+        when(jobRepository.findById(1L)).thenReturn(Optional.of(existingJob));
+        when(jobRepository.save(any(Job.class))).thenReturn(existingJob);
+
+        ResponseEntity<ApiResponse> response = jobService.updateJob(1L, updatedDetails);
+        assertEquals("Job updated successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        verify(jobRepository).save(existingJob);
+    }
+
+    @Test
+    public void testDeleteJob() {
+        when(jobRepository.existsById(1L)).thenReturn(true);
+
+        ResponseEntity<ApiResponse> response = jobService.deleteJob(1L);
+        assertEquals("Job deleted successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        verify(jobRepository).deleteById(1L);
+    }
+}

--- a/PrinterService/src/test/java/org/repro3d/service/PrinterServiceTest.java
+++ b/PrinterService/src/test/java/org/repro3d/service/PrinterServiceTest.java
@@ -1,0 +1,98 @@
+package repro3d.service;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import repro3d.model.Printer;
+import repro3d.repository.PrinterRepository;
+import repro3d.utils.ApiResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class PrinterServiceTest {
+
+    @Autowired
+    private PrinterService printerService;
+
+    @MockBean
+    private PrinterRepository printerRepository;
+
+    @Test
+    public void testCreatePrinter() {
+        Printer printer = new Printer();
+        printer.setName("Test Printer");
+        when(printerRepository.save(any(Printer.class))).thenReturn(printer);
+
+        ResponseEntity<ApiResponse> response = printerService.createPrinter(printer);
+        assertEquals("Printer created successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(printer, response.getBody().getData());
+    }
+
+    @Test
+    public void testGetAllPrinters() {
+        Printer printer1 = new Printer();
+        Printer printer2 = new Printer();
+        when(printerRepository.findAll()).thenReturn(Arrays.asList(printer1, printer2));
+
+        ResponseEntity<ApiResponse> response = printerService.getAllPrinters();
+        assertEquals("Printers retrieved successfully", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(2, ((List<Printer>) response.getBody().getData()).size());
+    }
+
+    @Test
+    public void testGetPrinterById() {
+        Printer printer = new Printer();
+        printer.setPrinter_id(1L);
+        when(printerRepository.findById(1L)).thenReturn(Optional.of(printer));
+
+        ResponseEntity<ApiResponse> response = printerService.getPrinterById(1L);
+        assertEquals("Printer found.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(printer, response.getBody().getData());
+    }
+
+    @Test
+    public void testUpdatePrinter() {
+        Printer existingPrinter = new Printer();
+        existingPrinter.setPrinter_id(1L);
+        existingPrinter.setName("Old Printer");
+
+        Printer newDetails = new Printer();
+        newDetails.setName("Updated Printer");
+
+        when(printerRepository.findById(1L)).thenReturn(Optional.of(existingPrinter));
+        when(printerRepository.save(any(Printer.class))).thenReturn(existingPrinter);
+
+        ResponseEntity<ApiResponse> response = printerService.updatePrinter(1L, newDetails);
+        assertEquals("Printer updated successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        verify(printerRepository).save(existingPrinter);
+    }
+
+    @Test
+    public void testDeletePrinter() {
+        when(printerRepository.existsById(1L)).thenReturn(true);
+
+        ResponseEntity<ApiResponse> response = printerService.deletePrinter(1L);
+        assertEquals("Printer deleted successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        verify(printerRepository, times(1)).deleteById(1L);
+    }
+}

--- a/PrinterService/src/test/java/org/repro3d/service/StatusServiceTest.java
+++ b/PrinterService/src/test/java/org/repro3d/service/StatusServiceTest.java
@@ -1,0 +1,98 @@
+package repro3d.service;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import repro3d.model.Status;
+import repro3d.repository.StatusRepository;
+import repro3d.utils.ApiResponse;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class StatusServiceTest {
+
+    @Autowired
+    private StatusService statusService;
+
+    @MockBean
+    private StatusRepository statusRepository;
+
+    @Test
+    public void testCreateStatus() {
+        Status status = new Status();
+        status.setStatus("Active");
+        when(statusRepository.save(any(Status.class))).thenReturn(status);
+
+        ResponseEntity<ApiResponse> response = statusService.createStatus(status);
+        assertEquals("Status created successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(status, response.getBody().getData());
+    }
+
+    @Test
+    public void testGetAllStatuses() {
+        Status status1 = new Status();
+        Status status2 = new Status();
+        when(statusRepository.findAll()).thenReturn(Arrays.asList(status1, status2));
+
+        ResponseEntity<ApiResponse> response = statusService.getAllStatuses();
+        assertEquals("Statuses retrieved successfully", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(2, ((List<Status>) response.getBody().getData()).size());
+    }
+
+    @Test
+    public void testGetStatusById() {
+        Status status = new Status();
+        status.setStatus_id(1L);
+        when(statusRepository.findById(1L)).thenReturn(Optional.of(status));
+
+        ResponseEntity<ApiResponse> response = statusService.getStatusById(1L);
+        assertEquals("Status found.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        assertEquals(status, response.getBody().getData());
+    }
+
+    @Test
+    public void testUpdateStatus() {
+        Status existingStatus = new Status();
+        existingStatus.setStatus_id(1L);
+        existingStatus.setStatus("Active");
+
+        Status newDetails = new Status();
+        newDetails.setStatus("Inactive");
+
+        when(statusRepository.findById(1L)).thenReturn(Optional.of(existingStatus));
+        when(statusRepository.save(any(Status.class))).thenReturn(existingStatus);
+
+        ResponseEntity<ApiResponse> response = statusService.updateStatus(1L, newDetails);
+        assertEquals("Status updated successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        verify(statusRepository).save(existingStatus);
+    }
+
+    @Test
+    public void testDeleteStatus() {
+        when(statusRepository.existsById(1L)).thenReturn(true);
+
+        ResponseEntity<ApiResponse> response = statusService.deleteStatus(1L);
+        assertEquals("Status deleted successfully.", response.getBody().getMessage());
+        assertEquals(true, response.getBody().isSuccess());
+        verify(statusRepository, times(1)).deleteById(1L);
+    }
+}


### PR DESCRIPTION
## Description
This PR adds all the necessary components to cover CRUD functionality of the PrinterService module.
This includes Entities models, Controllers, Service classes and `ApiResponse` class as a utility class.

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes