### PR TITLE
feat: Add AuthService BasicAuth and Gateway API with transparent header forwarding RP-22

### DIFF
--- a/API-Gateway/pom.xml
+++ b/API-Gateway/pom.xml
@@ -4,6 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.repro3d</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>org.repro3d</groupId>
     <artifactId>API-Gateway</artifactId>
     <version>0.0.1-SNAPSHOT</version>
@@ -13,5 +20,20 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-gateway</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-web</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-config</artifactId>
+    </dependency>
+    </dependencies>
     
 </project>

--- a/API-Gateway/pom.xml
+++ b/API-Gateway/pom.xml
@@ -21,7 +21,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+
+
     <dependencies>
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+    </dependency>
     <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-gateway</artifactId>
@@ -34,6 +40,10 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
     </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+        </dependency>
     </dependencies>
     
 </project>

--- a/API-Gateway/src/main/java/repro3d/apigateway/AuthorizationHeaderFilter.java
+++ b/API-Gateway/src/main/java/repro3d/apigateway/AuthorizationHeaderFilter.java
@@ -1,0 +1,34 @@
+package repro3d.apigateway;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+
+@Component
+class AuthorizationHeaderFilter extends org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory<AuthorizationHeaderFilter.Config> {
+
+    public AuthorizationHeaderFilter() {
+        super(Config.class);
+    }
+
+    public static class Config {
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            if (request.getHeaders().containsKey("Authorization")) {
+                String authHeader = request.getHeaders().getFirst("Authorization");
+                ServerHttpRequest modifiedRequest = request.mutate().header("Authorization", authHeader).build();
+                return chain.filter(exchange.mutate().request(modifiedRequest).build());
+            }
+            return chain.filter(exchange);
+        };
+    }
+}

--- a/API-Gateway/src/main/java/repro3d/apigateway/EntryPointApiGateway.java
+++ b/API-Gateway/src/main/java/repro3d/apigateway/EntryPointApiGateway.java
@@ -1,0 +1,67 @@
+package repro3d.apigateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@SpringBootApplication
+@EnableDiscoveryClient
+@EnableWebFluxSecurity
+public class EntryPointApiGateway {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EntryPointApiGateway.class, args);
+    }
+
+    @Bean
+    // Replace placeholders with proper API routes
+    // Each service in question needs to have its own name inside application.properties in its module.
+    // This has to be filled for example in the AuthService module.
+    public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
+        return builder.routes()
+                .route(r -> r.path("/replace_placeholder/**")
+                        .uri("lb://auth-service"))
+                .route(r -> r.path("/replace_placeholder/**")
+                        .uri("lb://printer-service"))
+                .build();
+    }
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration corsConfig = new CorsConfiguration();
+        corsConfig.setAllowedOrigins(Arrays.asList("http://localhost:4200")); // Angular CLI default port
+        corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        corsConfig.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        corsConfig.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfig);
+
+        return new CorsWebFilter(source);
+    }
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http
+                .cors().configurationSource(request -> new CorsConfiguration().applyPermitDefaultValues())
+                .and()
+                .csrf().disable()
+                .authorizeExchange()
+                .pathMatchers("/api/**").authenticated()
+                .anyExchange().permitAll()
+                .and()
+                .httpBasic();
+        return http.build();
+    }
+}

--- a/API-Gateway/src/main/resources/application.properties
+++ b/API-Gateway/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+spring.application.name=api-gateway
+server.port=8765
+
+# Eureka Client Configuration
+eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
+eureka.client.register-with-eureka=true
+eureka.client.fetch-registry=true
+
+
+# Spring Cloud Gateway routes
+# Replace placeholders with actual routes
+spring.cloud.gateway.routes[0].id=auth-service
+spring.cloud.gateway.routes[0].uri=lb://auth-service
+spring.cloud.gateway.routes[0].predicates[0]=Path=/placeholder/**
+
+spring.cloud.gateway.routes[1].id=measurement-service
+spring.cloud.gateway.routes[1].uri=lb://measurement-service
+spring.cloud.gateway.routes[1].predicates[0]=Path=/measurements/**

--- a/API-Gateway/src/main/resources/application.properties
+++ b/API-Gateway/src/main/resources/application.properties
@@ -5,14 +5,18 @@ server.port=8765
 eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true
-
+logging.level.root=debug
 
 # Spring Cloud Gateway routes
 # Replace placeholders with actual routes
+#spring.cloud.gateway.routes[0].id=auth-service
 spring.cloud.gateway.routes[0].id=auth-service
 spring.cloud.gateway.routes[0].uri=lb://auth-service
-spring.cloud.gateway.routes[0].predicates[0]=Path=/placeholder/**
+spring.cloud.gateway.routes[0].predicates[0]=Path=/user/**
 
-spring.cloud.gateway.routes[1].id=measurement-service
-spring.cloud.gateway.routes[1].uri=lb://measurement-service
-spring.cloud.gateway.routes[1].predicates[0]=Path=/measurements/**
+spring.cloud.gateway.routes[1].id=order-service
+spring.cloud.gateway.routes[1].uri=lb://order-service
+spring.cloud.gateway.routes[1].predicates[0]=Path=/item/**
+#spring.cloud.gateway.routes[1].id=measurement-service
+#spring.cloud.gateway.routes[1].uri=lb://measurement-service
+#spring.cloud.gateway.routes[1].predicates[0]=Path=/measurements/**

--- a/AuthService/pom.xml
+++ b/AuthService/pom.xml
@@ -79,6 +79,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+
     </dependencies>
     
 </project>

--- a/AuthService/src/main/java/repro3d/SecurityConfig.java
+++ b/AuthService/src/main/java/repro3d/SecurityConfig.java
@@ -1,0 +1,79 @@
+package repro3d;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import repro3d.service.UserDetailsServiceImpl;
+
+import java.util.Arrays;
+
+/**
+ * This is a configuration class. No unit testing needed.
+ */
+@Configuration
+public class SecurityConfig {
+
+    @Autowired
+    UserDetailsServiceImpl userDetailsService;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Cors configuration, letting most things through.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:4200")); // Angular CLI default port
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder = httpSecurity.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder.userDetailsService(userDetailsService).passwordEncoder(bCryptPasswordEncoder());
+        AuthenticationManager authenticationManager = authenticationManagerBuilder.build();
+
+        // TODO fix these, so that they don't use deprecated code anymore
+        httpSecurity
+                .cors()
+                .and()
+                .csrf().disable()
+                .authorizeHttpRequests()
+                .anyRequest()
+                .authenticated()
+                .and()
+                .authenticationManager(authenticationManager)
+                .httpBasic();
+
+        return httpSecurity.build();
+    }
+
+
+}

--- a/AuthService/src/main/java/repro3d/SecurityConfig.java
+++ b/AuthService/src/main/java/repro3d/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:4200")); // Angular CLI default port
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:8765", "http://localhost:4200")); // Angular CLI default port
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
@@ -60,10 +60,7 @@ public class SecurityConfig {
         authenticationManagerBuilder.userDetailsService(userDetailsService).passwordEncoder(bCryptPasswordEncoder());
         AuthenticationManager authenticationManager = authenticationManagerBuilder.build();
 
-        // TODO fix these, so that they don't use deprecated code anymore
         httpSecurity
-                .cors()
-                .and()
                 .csrf().disable()
                 .authorizeHttpRequests()
                 .anyRequest()

--- a/AuthService/src/main/java/repro3d/service/UserDetailsServiceImpl.java
+++ b/AuthService/src/main/java/repro3d/service/UserDetailsServiceImpl.java
@@ -1,0 +1,36 @@
+package repro3d.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import repro3d.model.User;
+import repro3d.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        Optional<User> userDetails = userRepository.findByEmail(email);
+
+        if (userDetails.isEmpty()) {
+            throw new UsernameNotFoundException("User with username: " + email + " not found");
+        }
+
+
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(userDetails.get().getEmail())
+                .password(userDetails.get().getPasswordHash())
+                .build();
+    }
+}

--- a/AuthService/src/main/resources/application.properties
+++ b/AuthService/src/main/resources/application.properties
@@ -1,5 +1,13 @@
+spring.application.name=auth-service
+server.port=8070
 eureka.client.enabled=false
 spring.datasource.url=jdbc:mariadb://x/x
 spring.datasource.username=x
 spring.datasource.password=x
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+
+
+# Eureka Client Configuration
+eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
+eureka.client.register-with-eureka=true
+eureka.client.fetch-registry=true

--- a/AuthService/src/main/resources/application.properties
+++ b/AuthService/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=auth-service
 server.port=8070
-eureka.client.enabled=false
-spring.datasource.url=jdbc:mariadb://x/x
+spring.datasource.url=jdbc:mariadb://x/AuthDb
 spring.datasource.username=x
 spring.datasource.password=x
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+logging.level.root=debug
 
 
 # Eureka Client Configuration

--- a/DiscoveryServer/pom.xml
+++ b/DiscoveryServer/pom.xml
@@ -8,10 +8,24 @@
     <artifactId>DiscoveryServer</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+    <parent>
+        <groupId>org.repro3d</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath> <!-- Adjust if necessary -->
+    </parent>
+
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+    </dependency>
+    </dependencies>
     
 </project>

--- a/DiscoveryServer/src/main/java/org/repro3d/discoveryserver/EntryPointDiscoveryServer.java
+++ b/DiscoveryServer/src/main/java/org/repro3d/discoveryserver/EntryPointDiscoveryServer.java
@@ -1,0 +1,19 @@
+package org.repro3d.discoveryserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+public class EntryPointDiscoveryServer {
+
+    /**
+     * Main method to start the DiscoveryServer application.
+     *
+     * @param args Command line arguments passed during the application start.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(EntryPointDiscoveryServer.class, args);
+    }
+}

--- a/DiscoveryServer/src/main/resources/application.properties
+++ b/DiscoveryServer/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=discovery-server
+server.port=8761

--- a/DiscoveryServer/src/main/resources/application.properties
+++ b/DiscoveryServer/src/main/resources/application.properties
@@ -1,2 +1,9 @@
+# Application properties
 spring.application.name=discovery-server
 server.port=8761
+
+
+# Enable Eureka Server
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+eureka.server.enable-self-preservation=false

--- a/OrderService/src/main/resources/application.properties
+++ b/OrderService/src/main/resources/application.properties
@@ -1,7 +1,12 @@
-spring.config.import=
+spring.application.name=order-service
+server.port=8071
 spring.datasource.url=jdbc:mariadb://x/OrderDb
 spring.datasource.username=x
 spring.datasource.password=x
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
-eureka.client.enabled=false
+
+
+# Eureka Client Configuration
+eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
+eureka.client.register-with-eureka=true
+eureka.client.fetch-registry=true


### PR DESCRIPTION
## Description
Added BasicAuth authentication to the AuthService. Added Gateway API that forwards the headers to the services themselves, where they will be processed for validity.

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:
Go over all the following points, and replace the whitespace with an `x` in all the boxes that apply.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
