### PR TITLE
feat: add backend side password hashing and rolesetting when registering RP-22

### DIFF
--- a/AuthService/src/main/java/org/repro3d/service/UserService.java
+++ b/AuthService/src/main/java/org/repro3d/service/UserService.java
@@ -1,9 +1,11 @@
 package org.repro3d.service;
 
+import org.repro3d.model.Role;
 import org.repro3d.repository.RoleRepository;
 import org.repro3d.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 import org.repro3d.model.User;
 import org.repro3d.utils.ApiResponse;
@@ -45,6 +47,8 @@ public class UserService {
         if (user.getRole() != null && !roleRepository.existsById(user.getRole().getRoleId())) {
             return ResponseEntity.badRequest().body(new ApiResponse(false, "Role not found for ID: " + user.getRole().getRoleId(), null));
         }
+        user.setRole(new Role(2L, ""));
+        user.setPasswordHash(BCrypt.hashpw(user.getPasswordHash(), BCrypt.gensalt()));
         User savedUser = userRepository.save(user);
         return ResponseEntity.ok(new ApiResponse(true, "User created successfully", savedUser));
     }


### PR DESCRIPTION
## Description
Backend side password hashing was only presend when logging in. This PR adds it to the registering side as well. Also sets the role automatically to 2, which should always be the User.

## Related Issue(s)
RP-22

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:
Go over all the following points, and replace the whitespace with an `x` in all the boxes that apply.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
