### PR TITLE
refactor: Support supplying RC code itself in POST method

### DIFF
--- a/OrderService/src/main/java/org/repro3d/model/Order.java
+++ b/OrderService/src/main/java/org/repro3d/model/Order.java
@@ -58,11 +58,11 @@ public class Order {
         this.user.setUserId(userId);
     }
 
-    @JsonSetter("rc_id")
-    public void setRedeemCodeById(Long rcId) {
+    @JsonSetter("redeemCode")
+    public void setRedeemCodeByCode(String rcCode) {
         if (this.redeemCode == null) {
             this.redeemCode = new RedeemCode();
         }
-        this.redeemCode.setRc_id(rcId);
+        this.redeemCode.setRcCode(rcCode);
     }
 }

--- a/OrderService/src/main/java/org/repro3d/service/OrderService.java
+++ b/OrderService/src/main/java/org/repro3d/service/OrderService.java
@@ -54,16 +54,16 @@ public class OrderService {
             return ResponseEntity.badRequest().body(new ApiResponse(false, "User not found for ID: " + (order.getUser() != null ? order.getUser().getUserId() : "null"), null));
         }
 
-        if (order.getRedeemCode() == null || !redeemCodeRepository.existsById(order.getRedeemCode().getRc_id())) {
-            return ResponseEntity.badRequest().body(new ApiResponse(false, "Redeem code not found for ID: " + (order.getRedeemCode() != null ? order.getRedeemCode().getRc_id() : "null"), null));
+        if (order.getRedeemCode() == null || !redeemCodeRepository.findByRcCode(order.getRedeemCode().getRcCode()).isPresent()) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, "Redeem code not found", null));
         }
 
-        Optional<RedeemCode> redeemCodeOpt = redeemCodeRepository.findById(order.getRedeemCode().getRc_id());
-        if (!redeemCodeOpt.isPresent() || redeemCodeOpt.get().getUsed()) {
+        RedeemCode redeemCode = redeemCodeRepository.findByRcCode(order.getRedeemCode().getRcCode()).orElse(null);
+        if (redeemCode == null || redeemCode.getUsed()) {
             return ResponseEntity.badRequest().body(new ApiResponse(false, "Invalid or already used redeem code.", null));
         }
 
-        order.setRedeemCode(redeemCodeOpt.get());
+        order.setRedeemCode(redeemCode);
         Order savedOrder = orderRepository.save(order);
         return ResponseEntity.ok(new ApiResponse(true, "Order created successfully.", savedOrder));
     }

--- a/OrderService/src/test/java/org/repro3d/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/repro3d/service/OrderServiceTest.java
@@ -51,17 +51,13 @@ public class OrderServiceTest {
     @Test
     void createOrderSuccessfully() {
         when(userRepository.existsById(user.getUserId())).thenReturn(true);
-        when(redeemCodeRepository.existsById(redeemCode.getRc_id())).thenReturn(true);
-        when(redeemCodeRepository.findById(redeemCode.getRc_id())).thenReturn(Optional.ofNullable(redeemCode));
-
+        when(redeemCodeRepository.findByRcCode(redeemCode.getRcCode())).thenReturn(Optional.of(redeemCode));
         when(orderRepository.save(any(Order.class))).thenReturn(order);
 
         ResponseEntity<ApiResponse> response = orderService.createOrder(order);
-        System.out.println(response.getBody().getMessage());
         assertEquals(200, response.getStatusCodeValue());
         assertTrue(response.getBody().isSuccess());
         assertEquals(order, response.getBody().getData());
-
     }
 
     @Test
@@ -77,7 +73,7 @@ public class OrderServiceTest {
     @Test
     void createOrderFailureRedeemCodeNotFound() {
         when(userRepository.existsById(user.getUserId())).thenReturn(true);
-        when(redeemCodeRepository.existsById(redeemCode.getRc_id())).thenReturn(false);
+        when(redeemCodeRepository.findByRcCode(redeemCode.getRcCode())).thenReturn(Optional.empty());
 
         ResponseEntity<ApiResponse> response = orderService.createOrder(order);
 
@@ -89,8 +85,7 @@ public class OrderServiceTest {
     void createOrderFailureRedeemCodeUsed() {
         redeemCode.setUsed(true);
         when(userRepository.existsById(user.getUserId())).thenReturn(true);
-        when(redeemCodeRepository.existsById(redeemCode.getRc_id())).thenReturn(true);
-        lenient().when(redeemCodeRepository.findById(redeemCode.getRc_id())).thenReturn(Optional.of(redeemCode));
+        when(redeemCodeRepository.findByRcCode(redeemCode.getRcCode())).thenReturn(Optional.of(redeemCode));
 
         ResponseEntity<ApiResponse> response = orderService.createOrder(order);
 


### PR DESCRIPTION
## Description
This PR includes change to the `createOrder` method in the `OrderService`.
This allows us to use the JSON body simillar to this to create order:

`{
            "orderDate": "2024-05-10",
            "user_id": 123,
            "redeemCode": "some_code"
}
`

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other (please describe): Refactor

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
