### PR TITLE
feat: Add "nulling" of rc_id in Orders when the RC gets deleted

### DIFF
--- a/BillingService/src/main/java/org/repro3d/repository/OrderRepository.java
+++ b/BillingService/src/main/java/org/repro3d/repository/OrderRepository.java
@@ -1,8 +1,11 @@
     package org.repro3d.repository;
 
     import org.repro3d.model.Order;
+    import org.repro3d.model.RedeemCode;
     import org.springframework.data.jpa.repository.JpaRepository;
     import org.springframework.stereotype.Repository;
+
+    import java.util.List;
 
     /**
      * Repository interface for {@link Order} entities.
@@ -10,4 +13,5 @@
      */
     @Repository
     public interface OrderRepository extends JpaRepository<Order, Long> {
+        List<Order> findAllByRedeemCode(RedeemCode redeemCode);
     }


### PR DESCRIPTION
## Description
PR does what the title says. It adds "nulling" (set to null) of rc_id field in Order entity when the RC gets deleted.
Otherwise we would have to break our foreign key constraint.

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
