### PR TITLE
feat: order single item to print proceed to checkout RP-135

### DIFF
--- a/OrderService/src/main/java/org/repro3d/model/PlaceOrder.java
+++ b/OrderService/src/main/java/org/repro3d/model/PlaceOrder.java
@@ -1,0 +1,21 @@
+package org.repro3d.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A custom RequestBody for Order and Item.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceOrder {
+    Order order;
+    Item[] items;
+}

--- a/OrderService/src/main/java/org/repro3d/service/OrderItemsService.java
+++ b/OrderService/src/main/java/org/repro3d/service/OrderItemsService.java
@@ -1,5 +1,6 @@
 package org.repro3d.service;
 
+import org.repro3d.model.Job;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,25 @@ public class OrderItemsService {
         boolean orderExists = orderRepository.existsById(orderItems.getOrder().getOrder_id());
 
         if (!jobExists || !orderExists) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, "Job or Order does not exist, cannot create OrderItem", null));
+        }
+
+        OrderItems savedOrderItems = orderItemsRepository.save(orderItems);
+        return ResponseEntity.ok(new ApiResponse(true, "Order item created successfully.", savedOrderItems));
+    }
+
+    /**
+     * Creates and saves a new order with a new job.
+     *
+     * @param orderItems The order item to be created.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the result of the create operation.
+     */
+    public ResponseEntity<ApiResponse> placeOrderItem(OrderItems orderItems, Job job) {
+        Job j = jobRepository.save(job);
+        orderItems.setJob(j);
+        boolean orderExists = orderRepository.existsById(orderItems.getOrder().getOrder_id());
+
+        if (!orderExists) {
             return ResponseEntity.badRequest().body(new ApiResponse(false, "Job or Order does not exist, cannot create OrderItem", null));
         }
 


### PR DESCRIPTION
## Description
Created a /place endpoint for placing orders. Left the regular /order POST endpoint in place. The new function creates an order_items entity and a job entity for the order.

## Related Issue(s)
RP-135


## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:
Go over all the following points, and replace the whitespace with an `x` in all the boxes that apply.

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

