### PR TITLE
feat: Add retrieving of all `OrderItems` by `orderId`

### DIFF
--- a/API-Gateway/src/main/java/org/repro3d/apigateway/EntryPointApiGateway.java
+++ b/API-Gateway/src/main/java/org/repro3d/apigateway/EntryPointApiGateway.java
@@ -43,6 +43,10 @@ public class EntryPointApiGateway {
                         .uri("lb://auth-service"))
                 .route(r -> r.path("/api/item/**")
                         .uri("lb://order-service"))
+                .route(r -> r.path("/api/order-item/**")
+                        .uri("lb://order-service"))
+                .route(r -> r.path("/api/config/**")
+                        .uri("lb://auth-service"))
                 .build();
     }
 

--- a/BillingService/src/main/java/org/repro3d/model/Order.java
+++ b/BillingService/src/main/java/org/repro3d/model/Order.java
@@ -24,7 +24,8 @@ public class Order {
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long order_id;
+    @Column(name = "order_id")
+    private Long orderId;
 
     /**
      * The date and time when the order was placed.

--- a/BillingService/src/main/java/org/repro3d/service/ReceiptService.java
+++ b/BillingService/src/main/java/org/repro3d/service/ReceiptService.java
@@ -41,7 +41,7 @@ public class ReceiptService {
      * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the result of the create operation.
      */
     public ResponseEntity<ApiResponse> createReceipt(Receipt receipt) {
-        Optional<Order> order = orderRepository.findById(receipt.getOrder().getOrder_id());
+        Optional<Order> order = orderRepository.findById(receipt.getOrder().getOrderId());
         if (!order.isPresent()) {
             return ResponseEntity.badRequest().body(new ApiResponse(false, "Order does not exist.", null));
         }
@@ -81,7 +81,7 @@ public class ReceiptService {
      */
     public ResponseEntity<ApiResponse> updateReceipt(Long id, Receipt receiptDetails) {
         return receiptRepository.findById(id).flatMap(receipt -> {
-            Optional<Order> order = orderRepository.findById(receiptDetails.getOrder().getOrder_id());
+            Optional<Order> order = orderRepository.findById(receiptDetails.getOrder().getOrderId());
             if (!order.isPresent()) {
                 return Optional.of(ResponseEntity.badRequest().body(new ApiResponse(false, "Order does not exist.", null)));
             }

--- a/OrderService/src/main/java/org/repro3d/controller/OrderItemsController.java
+++ b/OrderService/src/main/java/org/repro3d/controller/OrderItemsController.java
@@ -1,5 +1,6 @@
 package org.repro3d.controller;
 
+import org.repro3d.model.Order;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -61,6 +62,16 @@ public class OrderItemsController {
     }
 
     /**
+     * Retrieves all order_id items by order_id.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list
+     *         of all order_id items belonging to that order_id.
+     */
+    @GetMapping("/by-order/{order_id}")
+    public ResponseEntity<ApiResponse> getAllOrderItemsByOrderId(@PathVariable Order order_id) {
+        return orderItemsService.getAllOrderItemsByOrder(order_id);
+    }
+
+    /**
      * Updates the details of an existing order item.
      * @param id The ID of the order item to update.
      * @param orderItemsDetails The new details for the order item.
@@ -83,17 +94,5 @@ public class OrderItemsController {
         return orderItemsService.deleteOrderItem(id);
     }
 
-    /**
-     * Retrieves all order items associated with a given order ID.
-     * @param orderId The ID of the order for which order items are to be retrieved.
-     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list of order items
-     *         associated with the specified order ID, or an error message if the order ID does not exist
-     *         or no items are found.
-     */
-
-    @GetMapping("/by-order/{orderId}")
-    public ResponseEntity<ApiResponse> getOrderItemsByOrderId(@PathVariable Long orderId) {
-        return orderItemsService.getOrderItemsByOrderId(orderId);
-    }
 
 }

--- a/OrderService/src/main/java/org/repro3d/controller/OrderItemsController.java
+++ b/OrderService/src/main/java/org/repro3d/controller/OrderItemsController.java
@@ -82,4 +82,18 @@ public class OrderItemsController {
     public ResponseEntity<ApiResponse> deleteOrderItem(@PathVariable Long id) {
         return orderItemsService.deleteOrderItem(id);
     }
+
+    /**
+     * Retrieves all order items associated with a given order ID.
+     * @param orderId The ID of the order for which order items are to be retrieved.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list of order items
+     *         associated with the specified order ID, or an error message if the order ID does not exist
+     *         or no items are found.
+     */
+
+    @GetMapping("/by-order/{orderId}")
+    public ResponseEntity<ApiResponse> getOrderItemsByOrderId(@PathVariable Long orderId) {
+        return orderItemsService.getOrderItemsByOrderId(orderId);
+    }
+
 }

--- a/OrderService/src/main/java/org/repro3d/model/Job.java
+++ b/OrderService/src/main/java/org/repro3d/model/Job.java
@@ -39,7 +39,7 @@ public class Job {
      * The printer assigned to this job. It is a many-to-one relationship since
      * multiple jobs can be assigned to a single printer.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "printer_id", referencedColumnName = "printer_id")
     private Printer printer;
 
@@ -47,7 +47,7 @@ public class Job {
      * The current status of the job. It is a many-to-one relationship since
      * multiple jobs can share the same status (e.g., 'Pending', 'Completed').
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "status_id",  referencedColumnName = "status_id")
     private Status status;
 

--- a/OrderService/src/main/java/org/repro3d/model/Order.java
+++ b/OrderService/src/main/java/org/repro3d/model/Order.java
@@ -24,7 +24,8 @@ public class Order {
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long order_id;
+    @Column(name = "order_id")
+    private Long orderId;
 
     /**
      * The date and time when the order was placed.

--- a/OrderService/src/main/java/org/repro3d/model/OrderItems.java
+++ b/OrderService/src/main/java/org/repro3d/model/OrderItems.java
@@ -1,13 +1,10 @@
 package org.repro3d.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.repro3d.model.Item;
-import org.repro3d.model.Job;
-import org.repro3d.model.Order;
-
 /**
  * Represents the association between an order and its items, detailing the items
  * that are part of each order. It also includes references to external job IDs
@@ -32,6 +29,7 @@ public class OrderItems {
      * many-to-one association, as each order can contain multiple items.
      */
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     @JoinColumn(name = "item_id", referencedColumnName = "item_id")
     private Item item;
 
@@ -40,6 +38,7 @@ public class OrderItems {
      * handling the item within the context of this order.
      */
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     @JoinColumn(name = "job_id", referencedColumnName = "job_id")
     private Job job;
 
@@ -49,6 +48,7 @@ public class OrderItems {
      * order-item associations) can belong to a single order.
      */
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     @JoinColumn(name = "order_id", referencedColumnName = "order_id")
     private Order order;
 }

--- a/OrderService/src/main/java/org/repro3d/model/OrderItems.java
+++ b/OrderService/src/main/java/org/repro3d/model/OrderItems.java
@@ -28,7 +28,7 @@ public class OrderItems {
      * The item associated with this order. This relationship is managed with a
      * many-to-one association, as each order can contain multiple items.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     @JoinColumn(name = "item_id", referencedColumnName = "item_id")
     private Item item;
@@ -37,7 +37,7 @@ public class OrderItems {
      * The job associated with this order item. This is linked to a specific job
      * handling the item within the context of this order.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     @JoinColumn(name = "job_id", referencedColumnName = "job_id")
     private Job job;
@@ -47,7 +47,7 @@ public class OrderItems {
      * relationship, indicating that multiple items (and thus multiple
      * order-item associations) can belong to a single order.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     @JoinColumn(name = "order_id", referencedColumnName = "order_id")
     private Order order;

--- a/OrderService/src/main/java/org/repro3d/repository/OrderItemsRepository.java
+++ b/OrderService/src/main/java/org/repro3d/repository/OrderItemsRepository.java
@@ -5,10 +5,13 @@ import org.repro3d.model.OrderItems;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 /**
  * Repository interface for {@link Order} entities.
  * This interface extends JpaRepository, providing CRUD operations and additional methods to interact with the OrderItems data.
  */
 @Repository
 public interface OrderItemsRepository extends JpaRepository<OrderItems, Long> {
+    List<OrderItems> findByOrder_OrderId(Long orderId);
 }

--- a/OrderService/src/main/java/org/repro3d/repository/OrderItemsRepository.java
+++ b/OrderService/src/main/java/org/repro3d/repository/OrderItemsRepository.java
@@ -13,5 +13,5 @@ import java.util.List;
  */
 @Repository
 public interface OrderItemsRepository extends JpaRepository<OrderItems, Long> {
-    List<OrderItems> findByOrder_OrderId(Long orderId);
+    List<OrderItems> findByOrder(Order order);
 }

--- a/OrderService/src/main/java/org/repro3d/service/OrderItemsService.java
+++ b/OrderService/src/main/java/org/repro3d/service/OrderItemsService.java
@@ -1,6 +1,7 @@
 package org.repro3d.service;
 
 import org.repro3d.model.Job;
+import org.repro3d.model.Order;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -82,8 +83,8 @@ public class OrderItemsService {
      * @return A {@link ResponseEntity} containing an {@link ApiResponse} with a list of all order items.
      */
     public ResponseEntity<ApiResponse> getAllOrderItems() {
-        List<OrderItems> orderItems = orderItemsRepository.findAll();
-        if (!orderItems.isEmpty()) {
+        Iterable<OrderItems> orderItems = orderItemsRepository.findAll();
+        if (orderItems.iterator().hasNext()) {
             return ResponseEntity.ok(new ApiResponse(true, "Order items retrieved successfully.", orderItems));
         } else {
             return ResponseEntity.ok(new ApiResponse(false, "No order items found.", null));
@@ -102,6 +103,21 @@ public class OrderItemsService {
             return ResponseEntity.ok(new ApiResponse(true, "Order item retrieved successfully.", orderItem.get()));
         } else {
             return ResponseEntity.ok(new ApiResponse(false, "Order item not found for ID: " + id, null));
+        }
+    }
+
+    /**
+     * Retrieves an order item by its order entity.
+     *
+     * @param {@link Order} The order of the order items to retrieve.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the order item, if found.
+     */
+    public ResponseEntity<ApiResponse> getAllOrderItemsByOrder(Order order) {
+        List<OrderItems> orderItem = orderItemsRepository.findByOrder(order);
+        if (!orderItem.isEmpty()) {
+            return ResponseEntity.ok(new ApiResponse(true, "Order item retrieved successfully.", orderItem));
+        } else {
+            return ResponseEntity.ok(new ApiResponse(false, "Order item not found for ID: " + order.getOrderId(), null));
         }
     }
 
@@ -143,25 +159,4 @@ public class OrderItemsService {
         }
     }
 
-    /**
-     * Retrieves all order items associated with a given order ID.
-     *
-     * @param orderId The ID of the order for which order items are to be retrieved.
-     *                This ID is used to check the existence of the order and to fetch the related order items.
-     * @return A {@link ResponseEntity} containing an {@link ApiResponse} indicating the result of the operation.
-     */
-
-    public ResponseEntity<ApiResponse> getOrderItemsByOrderId(Long orderId) {
-        boolean orderExists = orderRepository.existsById(orderId);
-        if (!orderExists) {
-            return ResponseEntity.ok(new ApiResponse(false, "Order not found for Order ID: " + orderId, null));
-        }
-
-        List<OrderItems> orderItems = orderItemsRepository.findByOrder_OrderId(orderId);
-        if (orderItems.isEmpty()) {
-            return ResponseEntity.ok(new ApiResponse(false, "No items found for Order ID: " + orderId, null));
-        } else {
-            return ResponseEntity.ok(new ApiResponse(true, "Order items retrieved successfully.", orderItems));
-        }
-    }
 }

--- a/OrderService/src/test/java/org/repro3d/service/OrderItemsServiceTest.java
+++ b/OrderService/src/test/java/org/repro3d/service/OrderItemsServiceTest.java
@@ -46,7 +46,7 @@ class OrderItemsServiceTest {
         orderItem.setOi_id(1L);
 
         Order order = new Order();
-        order.setOrder_id(1L);
+        order.setOrderId(1L);
 
         Job job = new Job();
         job.setJob_id(1L);

--- a/OrderService/src/test/java/org/repro3d/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/repro3d/service/OrderServiceTest.java
@@ -116,7 +116,7 @@ public class OrderServiceTest {
 
     @Test
     void updateOrderFoundAndValid() {
-        lenient().when(orderRepository.findById((order.getOrder_id()))).thenReturn(Optional.of(order));
+        lenient().when(orderRepository.findById((order.getOrderId()))).thenReturn(Optional.of(order));
         lenient().when(userRepository.existsById(user.getUserId())).thenReturn(true);
         lenient().when(redeemCodeRepository.existsById(redeemCode.getRc_id())).thenReturn(true);
         lenient().when(redeemCodeRepository.findById(redeemCode.getRc_id())).thenReturn(Optional.of(redeemCode));
@@ -140,7 +140,7 @@ public class OrderServiceTest {
     @Test
     void updateOrderFailureRedeemCodeUsed() {
         redeemCode.setUsed(true);
-        lenient().when(orderRepository.findById((order.getOrder_id()))).thenReturn(Optional.of(order));
+        lenient().when(orderRepository.findById((order.getOrderId()))).thenReturn(Optional.of(order));
         lenient().when(userRepository.existsById(user.getUserId())).thenReturn(true);
         lenient().when(redeemCodeRepository.existsById(redeemCode.getRc_id())).thenReturn(true);
         when(redeemCodeRepository.findById(redeemCode.getRc_id())).thenReturn(Optional.of(redeemCode));


### PR DESCRIPTION
## Description
This PR adds an option to retrieve all `OrderItems` by supplying the `orderId` to the end point:

`/api/order-item/by-order/{orderId}`

## Related Issue(s)
RP-136


## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

