### PR TITLE
feat: Include endpoint for the frontend config RP-79

### DIFF
--- a/API-Gateway/src/main/java/org/repro3d/apigateway/EntryPointApiGateway.java
+++ b/API-Gateway/src/main/java/org/repro3d/apigateway/EntryPointApiGateway.java
@@ -33,6 +33,8 @@ public class EntryPointApiGateway {
                         .uri("lb://auth-service"))
                 .route(r -> r.path("/api/role/**")
                         .uri("lb://auth-service"))
+                .route(r -> r.path("/api/config/**")
+                        .uri("lb://auth-service"))
                 .route(r -> r.path("/api/order/**")
                         .uri("lb://order-service"))
                 .route(r -> r.path("/api/printer/**")

--- a/AuthService/src/main/java/org/repro3d/SecurityConfig.java
+++ b/AuthService/src/main/java/org/repro3d/SecurityConfig.java
@@ -80,6 +80,10 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.PUT, "/api/item")
                     .authenticated()
                 .and()
+                    .authorizeHttpRequests()
+                    .requestMatchers("/api/config")
+                    .permitAll()
+                .and()
                     .authenticationManager(authenticationManager)
                 .httpBasic();
 

--- a/AuthService/src/main/java/org/repro3d/SecurityConfig.java
+++ b/AuthService/src/main/java/org/repro3d/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
                     .authenticated()
                 .and()
                     .authorizeHttpRequests()
-                    .requestMatchers("/api/config")
+                    .requestMatchers("/api/config/**")
                     .permitAll()
                 .and()
                     .authenticationManager(authenticationManager)

--- a/AuthService/src/main/java/org/repro3d/controller/FrontConfigController.java
+++ b/AuthService/src/main/java/org/repro3d/controller/FrontConfigController.java
@@ -24,7 +24,7 @@ public class FrontConfigController {
         }
     }
 
-    @PostMapping
+    @PostMapping("/{key}")
     public ResponseEntity<ApiResponse> updateConfig(@RequestBody FrontConfig frontConfig) {
         FrontConfig updatedConfig = configService.saveOrUpdateConfig(frontConfig.getKey(), frontConfig.getValue());
         return ResponseEntity.ok(new ApiResponse(true, "Config updated successfully.", updatedConfig));

--- a/AuthService/src/main/java/org/repro3d/controller/FrontConfigController.java
+++ b/AuthService/src/main/java/org/repro3d/controller/FrontConfigController.java
@@ -1,0 +1,32 @@
+package org.repro3d.controller;
+
+import org.repro3d.model.FrontConfig;
+import org.repro3d.service.FrontConfigService;
+import org.repro3d.utils.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/config")
+public class FrontConfigController {
+
+    @Autowired
+    private FrontConfigService configService;
+
+    @GetMapping("/{key}")
+    public ResponseEntity<ApiResponse> getConfig(@PathVariable String key) {
+        FrontConfig config = configService.getConfigByKey(key);
+        if (config != null) {
+            return ResponseEntity.ok(new ApiResponse(true, "Config retrieved successfully.", config));
+        } else {
+            return ResponseEntity.ok(new ApiResponse(false, "Config not found.", null));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> updateConfig(@RequestBody FrontConfig frontConfig) {
+        FrontConfig updatedConfig = configService.saveOrUpdateConfig(frontConfig.getKey(), frontConfig.getValue());
+        return ResponseEntity.ok(new ApiResponse(true, "Config updated successfully.", updatedConfig));
+    }
+}

--- a/AuthService/src/main/java/org/repro3d/model/FrontConfig.java
+++ b/AuthService/src/main/java/org/repro3d/model/FrontConfig.java
@@ -1,0 +1,28 @@
+package org.repro3d.model;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "front_config")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FrontConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "config_key", unique = true, nullable = false)
+    private String key;
+
+    @Column(name = "config_value", nullable = false)
+    private String value;
+
+    public FrontConfig(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/AuthService/src/main/java/org/repro3d/repository/FrontConfigRepository.java
+++ b/AuthService/src/main/java/org/repro3d/repository/FrontConfigRepository.java
@@ -1,0 +1,8 @@
+package org.repro3d.repository;
+
+import org.repro3d.model.FrontConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FrontConfigRepository extends JpaRepository<FrontConfig, Long> {
+    FrontConfig findByKey(String key);
+}

--- a/AuthService/src/main/java/org/repro3d/repository/FrontConfigRepository.java
+++ b/AuthService/src/main/java/org/repro3d/repository/FrontConfigRepository.java
@@ -2,7 +2,10 @@ package org.repro3d.repository;
 
 import org.repro3d.model.FrontConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+
+@Repository
 public interface FrontConfigRepository extends JpaRepository<FrontConfig, Long> {
     FrontConfig findByKey(String key);
 }

--- a/AuthService/src/main/java/org/repro3d/service/FrontConfigService.java
+++ b/AuthService/src/main/java/org/repro3d/service/FrontConfigService.java
@@ -1,0 +1,27 @@
+package org.repro3d.service;
+
+import org.repro3d.model.FrontConfig;
+import org.repro3d.repository.FrontConfigRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FrontConfigService {
+
+    @Autowired
+    private FrontConfigRepository configRepository;
+
+    public FrontConfig getConfigByKey(String key) {
+        return configRepository.findByKey(key);
+    }
+
+    public FrontConfig saveOrUpdateConfig(String key, String value) {
+        FrontConfig config = configRepository.findByKey(key);
+        if (config == null) {
+            config = new FrontConfig(key, value);
+        } else {
+            config.setValue(value);
+        }
+        return configRepository.save(config);
+    }
+}

--- a/AuthService/src/main/java/org/repro3d/service/FrontConfigService.java
+++ b/AuthService/src/main/java/org/repro3d/service/FrontConfigService.java
@@ -2,14 +2,16 @@ package org.repro3d.service;
 
 import org.repro3d.model.FrontConfig;
 import org.repro3d.repository.FrontConfigRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class FrontConfigService {
 
-    @Autowired
     private FrontConfigRepository configRepository;
+
+    public FrontConfigService(FrontConfigRepository configRepository) {
+        this.configRepository = configRepository;
+    }
 
     public FrontConfig getConfigByKey(String key) {
         return configRepository.findByKey(key);


### PR DESCRIPTION
## Description
This PR includes the endpoint and the methods for the so-called `FrontConfig` which will act as a config server,
but in our backend.

## Related Issue(s)
RP-79


## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
