### PR TITLE
feat: Add printer selection logic for jobs and their execution RP-174

### DIFF
--- a/API-Gateway/src/main/java/org/repro3d/apigateway/EntryPointApiGateway.java
+++ b/API-Gateway/src/main/java/org/repro3d/apigateway/EntryPointApiGateway.java
@@ -49,6 +49,8 @@ public class EntryPointApiGateway {
                         .uri("lb://order-service"))
                 .route(r -> r.path("/api/config/**")
                         .uri("lb://auth-service"))
+                .route(r -> r.path("/api/job/**")
+                        .uri("lb://printer-service"))
                 .build();
     }
 

--- a/OpenAPI/openapi.yml
+++ b/OpenAPI/openapi.yml
@@ -1,0 +1,1167 @@
+openapi: 3.0.1
+info:
+  title: Repro3D API
+  version: 1.0.0
+  description: API documentation for the Repro3D system.
+servers:
+    - url: http://localhost:8765/
+paths:
+  /api/config/{key}:
+    parameters:
+      - name: key
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get config by key
+      responses:
+        '200':
+          description: Config retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    post:
+      summary: Update config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FrontConfig'
+      responses:
+        '200':
+          description: Config updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/receipt:
+    post:
+      summary: Create a new receipt
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Receipt'
+      responses:
+        '200':
+          description: Receipt created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all receipts
+      responses:
+        '200':
+          description: List of all receipts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/receipt/{id}:
+    get:
+      summary: Get receipt by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Receipt retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update receipt by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Receipt'
+      responses:
+        '200':
+          description: Receipt updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete receipt by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Receipt deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/redeem-code:
+    post:
+      summary: Create a new redeem code
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedeemCode'
+      responses:
+        '200':
+          description: Redeem code created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all redeem codes
+      responses:
+        '200':
+          description: List of all redeem codes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/redeem-code/{id}:
+    get:
+      summary: Get redeem code by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Redeem code retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update redeem code by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedeemCode'
+      responses:
+        '200':
+          description: Redeem code updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete redeem code by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Redeem code deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/role:
+    post:
+      summary: Create a new role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+      responses:
+        '200':
+          description: Role created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all roles
+      responses:
+        '200':
+          description: List of all roles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/role/{id}:
+    get:
+      summary: Get role by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Role retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update role by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+      responses:
+        '200':
+          description: Role updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete role by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Role deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/log-action:
+    post:
+      summary: Create a new log action
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogAction'
+      responses:
+        '200':
+          description: Log action created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all log actions
+      responses:
+        '200':
+          description: List of all log actions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/log-action/{id}:
+    get:
+      summary: Get log action by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Log action retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update log action by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogAction'
+      responses:
+        '200':
+          description: Log action updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete log action by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Log action deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/audit-log:
+    post:
+      summary: Create a new audit log
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditLog'
+      responses:
+        '200':
+          description: Audit log created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all audit logs
+      responses:
+        '200':
+          description: List of all audit logs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/audit-log/{id}:
+    get:
+      summary: Get audit log by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Audit log retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update audit log by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditLog'
+      responses:
+        '200':
+          description: Audit log updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete audit log by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Audit log deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/status:
+    post:
+      summary: Create a new status
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Status'
+      responses:
+        '200':
+          description: Status created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all statuses
+      responses:
+        '200':
+          description: List of all statuses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/status/{id}:
+    get:
+      summary: Get status by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Status retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update status by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Status'
+      responses:
+        '200':
+          description: Status updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete status by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Status deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/job:
+    post:
+      summary: Create a new job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Job'
+      responses:
+        '200':
+          description: Job created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all jobs
+      responses:
+        '200':
+          description: List of all jobs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/job/{id}:
+    get:
+      summary: Get job by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Job retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update job by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Job'
+      responses:
+        '200':
+          description: Job updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete job by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Job deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/printer:
+    post:
+      summary: Create a new printer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Printer'
+      responses:
+        '200':
+          description: Printer created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all printers
+      responses:
+        '200':
+          description: List of all printers
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/printer/{id}:
+    get:
+      summary: Get printer by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Printer retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update printer by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Printer'
+      responses:
+        '200':
+          description: Printer updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete printer by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Printer deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/printer/{id}/apikey:
+    get:
+      summary: Get printer API key by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Printer API key retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/printer/webcam/{id}:
+    get:
+      summary: Stream webcam footage for a printer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Webcam footage streamed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/item:
+    post:
+      summary: Create a new item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses:
+        '200':
+          description: Item created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all items
+      responses:
+        '200':
+          description: List of all items
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/item/{id}:
+    get:
+      summary: Get item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Item retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses:
+        '200':
+          description: Item updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Item deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/item/search:
+    get:
+      summary: Get items by name
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Items retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order:
+    post:
+      summary: Create a new order
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '200':
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all orders
+      responses:
+        '200':
+          description: List of all orders
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order/place:
+    post:
+      summary: Place a new order
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlaceOrder'
+      responses:
+        '200':
+          description: Order placed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order/{id}:
+    get:
+      summary: Get order by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update order by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '200':
+          description: Order updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete order by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order/email:
+    get:
+      summary: Get orders by user email
+      parameters:
+        - name: email
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Orders retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order-item:
+    post:
+      summary: Create a new order item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderItems'
+      responses:
+        '200':
+          description: Order item created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    get:
+      summary: Get all order items
+      responses:
+        '200':
+          description: List of all order items
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order-item/{id}:
+    get:
+      summary: Get order item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order item retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      summary: Update order item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderItems'
+      responses:
+        '200':
+          description: Order item updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      summary: Delete order item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order item deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /api/order-item/by-order/{order_id}:
+    get:
+      summary: Get order items by order ID
+      parameters:
+        - name: order_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Order items retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+components:
+  schemas:
+    ApiResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        data:
+          type: object
+          nullable: true
+    FrontConfig:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+    Receipt:
+      type: object
+      properties:
+        id:
+          type: integer
+        date:
+          type: string
+          format: date-time
+        total:
+          type: number
+          format: double
+    RedeemCode:
+      type: object
+      properties:
+        id:
+          type: integer
+        code:
+          type: string
+        valid:
+          type: boolean
+    Role:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    LogAction:
+      type: object
+      properties:
+        id:
+          type: integer
+        action:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    AuditLog:
+      type: object
+      properties:
+        id:
+          type: integer
+        event:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    Status:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    Job:
+      type: object
+      properties:
+        id:
+          type: integer
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/Status'
+    Printer:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        ipAddress:
+          type: string
+        apiKey:
+          type: string
+    Item:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        price:
+          type: number
+          format: double
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+        orderDate:
+          type: string
+          format: date-time
+        user:
+          $ref: '#/components/schemas/User'
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/Role'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    PlaceOrder:
+      type: object
+      properties:
+        order:
+          $ref: '#/components/schemas/Order'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+    OrderItems:
+      type: object
+      properties:
+        id:
+          type: integer
+        order:
+          $ref: '#/components/schemas/Order'
+        item:
+          $ref: '#/components/schemas/Item'
+

--- a/OrderService/src/main/java/org/repro3d/service/OrderItemsService.java
+++ b/OrderService/src/main/java/org/repro3d/service/OrderItemsService.java
@@ -65,17 +65,23 @@ public class OrderItemsService {
      * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the result of the create operation.
      */
     public ResponseEntity<ApiResponse> placeOrderItem(OrderItems orderItems, Job job) {
-        Job j = jobRepository.save(job);
-        orderItems.setJob(j);
+        if (orderItems.getOrder() == null) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, "Order is null, cannot create OrderItem or Job", null));
+        }
+
         boolean orderExists = orderRepository.existsById(orderItems.getOrder().getOrderId());
 
         if (!orderExists) {
-            return ResponseEntity.badRequest().body(new ApiResponse(false, "Job or Order does not exist, cannot create OrderItem", null));
+            return ResponseEntity.badRequest().body(new ApiResponse(false, "Order does not exist, cannot create OrderItem or Job", null));
         }
 
+        Job savedJob = jobRepository.save(job);
+        orderItems.setJob(savedJob);
+
         OrderItems savedOrderItems = orderItemsRepository.save(orderItems);
-        return ResponseEntity.ok(new ApiResponse(true, "Order item created successfully.", savedOrderItems));
+        return ResponseEntity.ok(new ApiResponse(true, "Order item and job created successfully.", savedOrderItems));
     }
+
 
     /**
      * Retrieves all order items from the database.

--- a/OrderService/src/main/java/org/repro3d/service/OrderService.java
+++ b/OrderService/src/main/java/org/repro3d/service/OrderService.java
@@ -63,6 +63,9 @@ public class OrderService {
             return ResponseEntity.badRequest().body(new ApiResponse(false, "Invalid or already used redeem code.", null));
         }
 
+        redeemCode.setUsed(true);
+        redeemCodeRepository.save(redeemCode);
+        
         order.setRedeemCode(redeemCode);
         Order savedOrder = orderRepository.save(order);
         return ResponseEntity.ok(new ApiResponse(true, "Order created successfully.", savedOrder));

--- a/PrinterService/src/main/java/org/repro3d/EntryPointPrinterService.java
+++ b/PrinterService/src/main/java/org/repro3d/EntryPointPrinterService.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -12,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * Uses DiscoveryClient.
  */
 @SpringBootApplication
+@EnableScheduling
 @EnableDiscoveryClient
 public class EntryPointPrinterService {
 

--- a/PrinterService/src/main/java/org/repro3d/controller/JobController.java
+++ b/PrinterService/src/main/java/org/repro3d/controller/JobController.java
@@ -77,6 +77,18 @@ public class JobController {
         return jobService.updateJob(id, job);
     }
 
+
+    /**
+     * Updates the status of a job from 3 to 4.
+     *
+     * @param id The ID of the job to update.
+     * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the updated job, or an error message if the job was not found.
+     */
+    @PutMapping("/mark-as-done/{id}")
+    public ResponseEntity<ApiResponse> markJobAsDone(@PathVariable Long id) {
+        return jobService.markAsDone(id);
+    }
+
     /**
      * Deletes a job by its ID.
      *

--- a/PrinterService/src/main/java/org/repro3d/controller/JobController.java
+++ b/PrinterService/src/main/java/org/repro3d/controller/JobController.java
@@ -79,7 +79,7 @@ public class JobController {
 
 
     /**
-     * Updates the status of a job from 3 to 4.
+     * Updates the status of a job to 'Done' if its current status is 'Awaiting Pick Up'.
      *
      * @param id The ID of the job to update.
      * @return A {@link ResponseEntity} containing an {@link ApiResponse} with the updated job, or an error message if the job was not found.

--- a/PrinterService/src/main/java/org/repro3d/model/Job.java
+++ b/PrinterService/src/main/java/org/repro3d/model/Job.java
@@ -26,7 +26,8 @@ public class Job {
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long job_id;
+    @Column(name = "job_id")
+    private Long jobId;
 
     /**
      * The item ID this job is associated with.

--- a/PrinterService/src/main/java/org/repro3d/model/Job.java
+++ b/PrinterService/src/main/java/org/repro3d/model/Job.java
@@ -32,7 +32,7 @@ public class Job {
     /**
      * The item ID this job is associated with.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "item_id", referencedColumnName = "item_id")
     private Item item;
 
@@ -40,7 +40,7 @@ public class Job {
      * The printer assigned to this job. It is a many-to-one relationship since
      * multiple jobs can be assigned to a single printer.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "printer_id")
     private Printer printer;
 
@@ -48,7 +48,7 @@ public class Job {
      * The current status of the job. It is a many-to-one relationship since
      * multiple jobs can share the same status (e.g., 'Pending', 'Completed').
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "status_id")
     private Status status;
 

--- a/PrinterService/src/main/java/org/repro3d/repository/JobRepository.java
+++ b/PrinterService/src/main/java/org/repro3d/repository/JobRepository.java
@@ -1,8 +1,11 @@
 package org.repro3d.repository;
 
+import org.repro3d.model.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.repro3d.model.Job;
+
+import java.util.List;
 
 /**
  * Repository interface for {@link Job} entities.
@@ -12,4 +15,6 @@ import org.repro3d.model.Job;
  */
 @Repository
 public interface JobRepository extends JpaRepository<Job, Long> {
+    List<Job> findByStatusOrderByJobIdAsc(Status status);
 }
+

--- a/PrinterService/src/main/java/org/repro3d/repository/JobRepository.java
+++ b/PrinterService/src/main/java/org/repro3d/repository/JobRepository.java
@@ -1,5 +1,6 @@
 package org.repro3d.repository;
 
+import org.repro3d.model.Printer;
 import org.repro3d.model.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -16,5 +17,9 @@ import java.util.List;
 @Repository
 public interface JobRepository extends JpaRepository<Job, Long> {
     List<Job> findByStatusOrderByJobIdAsc(Status status);
+
+    boolean existsByPrinterAndStatusNot(Printer printer, Status status);
+
+    boolean existsByPrinterAndStatus(Printer printer, Status status);
 }
 

--- a/PrinterService/src/main/java/org/repro3d/service/JobService.java
+++ b/PrinterService/src/main/java/org/repro3d/service/JobService.java
@@ -104,7 +104,6 @@ public class JobService {
 
     /**
      * Updates the status of a job to 'Done' if its current status is 'Awaiting Pick Up'.
-     * <p>
      * This method retrieves the job by its ID and checks if the current status ID is 3 (representing 'Awaiting Pick Up').
      * If the status is 'Awaiting Pick Up', it updates the status to 4 (representing 'Done') and saves the updated job in the repository.
      * If the status is not 'Awaiting Pick Up', it returns a bad request response.

--- a/PrinterService/src/main/java/org/repro3d/service/PrinterService.java
+++ b/PrinterService/src/main/java/org/repro3d/service/PrinterService.java
@@ -244,10 +244,22 @@ public class PrinterService {
 
             JsonNode jsonResponse = objectMapper.readTree(response);
             String state = jsonResponse.path("state").asText();
+            boolean isCompletionNull = jsonResponse.path("progress").path("completion").isNull();
+            boolean isPrintTimeLeftNull = jsonResponse.path("progress").path("printTimeLeft").isNull();
+
+            System.out.println("Job state: " + state);
+            System.out.println("Completion is null: " + isCompletionNull);
+            System.out.println("Print time left is null: " + isPrintTimeLeftNull);
+
+            // If completion and printTimeLeft are null, we consider the job done and ready for pickup (temporary)
+            if (isCompletionNull && isPrintTimeLeftNull) {
+                completeJob(job);
+                return true;
+            }
+
             double completion = jsonResponse.path("progress").path("completion").asDouble();
             int printTimeLeft = jsonResponse.path("progress").path("printTimeLeft").asInt();
 
-            System.out.println("Job state: " + state);
             System.out.println("Completion: " + completion);
             System.out.println("Print time left: " + printTimeLeft);
 

--- a/PrinterService/src/main/java/org/repro3d/utils/AppConfig.java
+++ b/PrinterService/src/main/java/org/repro3d/utils/AppConfig.java
@@ -4,12 +4,26 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Configuration class for application-wide beans.
+ * <p>
+ * This class provides the configuration for beans that will be used
+ * throughout the application, ensuring they are properly instantiated
+ * and managed by the Spring container.
+ */
 @Configuration
 public class AppConfig {
 
+    /**
+     * Creates and returns an {@link ObjectMapper} bean.
+     * <p>
+     * This bean is used for JSON serialization and deserialization throughout
+     * the application.
+     *
+     * @return a new instance of {@link ObjectMapper}
+     */
     @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
     }
 }
-

--- a/PrinterService/src/main/java/org/repro3d/utils/AppConfig.java
+++ b/PrinterService/src/main/java/org/repro3d/utils/AppConfig.java
@@ -1,0 +1,15 @@
+package org.repro3d.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}
+

--- a/PrinterService/src/main/java/org/repro3d/utils/JobScheduler.java
+++ b/PrinterService/src/main/java/org/repro3d/utils/JobScheduler.java
@@ -32,15 +32,14 @@ public class JobScheduler {
             System.out.println("Processing job ID: " + job.getJobId());
             List<Printer> printers = printerService.getPrinters();
             for (Printer printer : printers) {
-                System.out.println("Checking printer ID: " + printer.getPrinter_id());
                 if (printerService.isPrinterAvailable(printer)) {
                     System.out.println("Printer ID " + printer.getPrinter_id() + " is available.");
                     boolean jobStarted = printerService.startPrintJob(printer, job);
                     if (jobStarted) {
-                        job.setPrinter(printer);  // Set the printer for the job
-                        job.setStatus(new Status(2L, "In progress"));
-                        jobRepository.save(job);
                         System.out.println("Started job ID: " + job.getJobId() + " on printer ID: " + printer.getPrinter_id());
+                        job.setStatus(new Status(2L, "In Progress"));
+                        job.setPrinter(printer);
+                        jobRepository.save(job);
                         return;
                     } else {
                         System.out.println("Failed to start job ID: " + job.getJobId() + " on printer ID: " + printer.getPrinter_id());
@@ -55,7 +54,7 @@ public class JobScheduler {
     @Scheduled(fixedRate = 120000) // Check every 120 seconds
     public void checkInProgressJobs() {
         System.out.println("Checking for in-progress jobs...");
-        List<Job> inProgressJobs = jobRepository.findByStatusOrderByJobIdAsc(new Status(2L, "In progress"));
+        List<Job> inProgressJobs = jobRepository.findByStatusOrderByJobIdAsc(new Status(2L, "In Progress"));
         System.out.println("Found " + inProgressJobs.size() + " in-progress jobs.");
         for (Job job : inProgressJobs) {
             Printer printer = job.getPrinter();

--- a/PrinterService/src/main/java/org/repro3d/utils/JobScheduler.java
+++ b/PrinterService/src/main/java/org/repro3d/utils/JobScheduler.java
@@ -11,19 +11,39 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/**
+ * Component class for scheduling and managing job-related tasks.
+ * 
+ * This class handles the periodic checking of job statuses and
+ * manages the starting of new print jobs as well as the completion
+ * of in-progress jobs.
+ */
 @Component
 public class JobScheduler {
 
     private final JobRepository jobRepository;
     private final PrinterService printerService;
 
+    /**
+     * Constructs a {@code JobScheduler} with the necessary repositories and services.
+     *
+     * @param jobRepository  The repository used for data operations on jobs.
+     * @param printerService The service used for managing printers.
+     */
     @Autowired
     public JobScheduler(JobRepository jobRepository, PrinterService printerService) {
         this.jobRepository = jobRepository;
         this.printerService = printerService;
     }
 
-    @Scheduled(fixedRate = 60000) // Check every minute
+    /**
+     * Periodically checks for waiting jobs and starts them if a printer is available.
+     *
+     * This method is scheduled to run every minute. It retrieves jobs with the status
+     * "Waiting", checks for available printers, and starts the jobs on the available
+     * printers.
+     */
+    @Scheduled(fixedRate = 60000) // 60 seconds
     public void checkWaitingJobs() {
         System.out.println("Checking for waiting jobs...");
         List<Job> waitingJobs = jobRepository.findByStatusOrderByJobIdAsc(new Status(1L, "Waiting"));
@@ -51,7 +71,14 @@ public class JobScheduler {
         }
     }
 
-    @Scheduled(fixedRate = 120000) // Check every 120 seconds
+    /**
+     * Periodically checks for in-progress jobs and marks them as complete if they are finished.
+     *
+     * This method is scheduled to run every 120 seconds. It retrieves jobs with the status
+     * "In Progress", checks their completion status, and marks them as "Awaiting Pick Up"
+     * if they are complete.
+     */
+    @Scheduled(fixedRate = 120000) // 120 seconds
     public void checkInProgressJobs() {
         System.out.println("Checking for in-progress jobs...");
         List<Job> inProgressJobs = jobRepository.findByStatusOrderByJobIdAsc(new Status(2L, "In Progress"));
@@ -73,4 +100,3 @@ public class JobScheduler {
         }
     }
 }
-

--- a/PrinterService/src/main/java/org/repro3d/utils/JobScheduler.java
+++ b/PrinterService/src/main/java/org/repro3d/utils/JobScheduler.java
@@ -1,0 +1,77 @@
+package org.repro3d.utils;
+
+import org.repro3d.model.Job;
+import org.repro3d.model.Printer;
+import org.repro3d.model.Status;
+import org.repro3d.repository.JobRepository;
+import org.repro3d.service.PrinterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class JobScheduler {
+
+    private final JobRepository jobRepository;
+    private final PrinterService printerService;
+
+    @Autowired
+    public JobScheduler(JobRepository jobRepository, PrinterService printerService) {
+        this.jobRepository = jobRepository;
+        this.printerService = printerService;
+    }
+
+    @Scheduled(fixedRate = 60000) // Check every minute
+    public void checkWaitingJobs() {
+        System.out.println("Checking for waiting jobs...");
+        List<Job> waitingJobs = jobRepository.findByStatusOrderByJobIdAsc(new Status(1L, "Waiting"));
+        System.out.println("Found " + waitingJobs.size() + " waiting jobs.");
+        for (Job job : waitingJobs) {
+            System.out.println("Processing job ID: " + job.getJobId());
+            List<Printer> printers = printerService.getPrinters();
+            for (Printer printer : printers) {
+                System.out.println("Checking printer ID: " + printer.getPrinter_id());
+                if (printerService.isPrinterAvailable(printer)) {
+                    System.out.println("Printer ID " + printer.getPrinter_id() + " is available.");
+                    boolean jobStarted = printerService.startPrintJob(printer, job);
+                    if (jobStarted) {
+                        job.setPrinter(printer);  // Set the printer for the job
+                        job.setStatus(new Status(2L, "In progress"));
+                        jobRepository.save(job);
+                        System.out.println("Started job ID: " + job.getJobId() + " on printer ID: " + printer.getPrinter_id());
+                        return;
+                    } else {
+                        System.out.println("Failed to start job ID: " + job.getJobId() + " on printer ID: " + printer.getPrinter_id());
+                    }
+                } else {
+                    System.out.println("Printer ID " + printer.getPrinter_id() + " is not available.");
+                }
+            }
+        }
+    }
+
+    @Scheduled(fixedRate = 120000) // Check every 120 seconds
+    public void checkInProgressJobs() {
+        System.out.println("Checking for in-progress jobs...");
+        List<Job> inProgressJobs = jobRepository.findByStatusOrderByJobIdAsc(new Status(2L, "In progress"));
+        System.out.println("Found " + inProgressJobs.size() + " in-progress jobs.");
+        for (Job job : inProgressJobs) {
+            Printer printer = job.getPrinter();
+            if (printer != null) {
+                System.out.println("Checking job completion for job ID: " + job.getJobId() + " on printer ID: " + printer.getPrinter_id());
+                if (printerService.isJobComplete(printer, job)) {
+                    System.out.println("Job ID: " + job.getJobId() + " is complete.");
+                    printerService.completeJob(job);
+                    checkWaitingJobs();
+                } else {
+                    System.out.println("Job ID: " + job.getJobId() + " is still in progress.");
+                }
+            } else {
+                System.out.println("No printer assigned to job ID: " + job.getJobId());
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Description
This PR covers the following:
- Adds scheduled task to check jobs with the `Waiting` status
- Check availability of printers
- If printer is available and there is a job with `Waiting` status -> start printing of said job and change its status to
"In Progress"
- If there is job which was successfully printed -> change its status to "Awaiting Pick Up"

Printer is considered unavailable if:
1) It doesnt accept connection.
2) It has job with status of "In Progress" or "Awaiting Pick Up" assigned to it.

## Related Issue(s)
RP-174

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

